### PR TITLE
Deleting .cvsignore

### DIFF
--- a/.cvsignore
+++ b/.cvsignore
@@ -1,9 +1,0 @@
-Makefile.in
-Makefile
-aclocal.m4
-configure
-config.log
-config.h
-config.cache
-config.status
-stamp-h


### PR DESCRIPTION
No longer need this, not in cvs anymore