### PR TITLE
added make target coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ exported.sym
 stamp-h1
 stamp-vti
 test_vars
+
+# gcovr files
+src/*.gcno
+tests/*.gcda
+tests/*.gcno

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,6 +36,12 @@ pcdata_DATA = check.pc
 
 DISTCLEANFILES = check_stdint.h
 
+# the gcovr binary to use
+GCOVR ?= gcovr
+# the minimal coverage for source files tested with `make check` in the
+# `coverage` target to be accepted (`make coverage` fails otherwise)
+GCOVR_COVERAGE_MIN ?= 100
+
 ACLOCAL_AMFLAGS = -I m4
 
 doc/check_html:
@@ -51,5 +57,10 @@ prereleasecheck: doc/check_html doc/doxygen
 	autoreconf -i && ./configure \
 	    && ulimit -c 0 && \
 	    $(MAKE) distcheck
+coverage:
+	$(MAKE) clean # clean first because change of CFLAGS isn't recognized
+	$(MAKE) CFLAGS='-g -O0 --coverage'
+	$(MAKE) check
+	$(GCOVR) -coverage-min=$(GCOVR_COVERAGE_MIN) . || echo "Make sure you have at least 3.2-11-g7390fa3 of https://github.com/krichter722/gcovr.git installed"
 
 .PHONY: prereleasecheck

--- a/configure.ac
+++ b/configure.ac
@@ -171,6 +171,17 @@ case "${host_os}" in
     ;;
 esac
 
+AC_CHECK_PROG(GCOVR_CHECK,gcovr,yes)
+if test x"$GCOVR_CHECK" != x"yes" ; then
+    AC_MSG_ERROR([Please install gcovr costumization from https://github.com/krichter722/gcovr before building.])
+fi
+if bash -c 'TEMP=$(mktemp -d); touch $TEMP/empty.py; gcovr -coverage-min=0.0 $TEMP'
+then
+  AC_MSG_NOTICE([gcovr costumization installed and working])
+else
+  AC_MSG_ERROR([Please install gcovr customization from https://github.com/krichter722/gcovr before building.])
+fi
+
 AC_CHECK_PROGS(GCOV, gcov, false)
 AC_CHECK_PROGS(LCOV, lcov, false)
 AC_CHECK_PROGS(GENHTML, genhtml, false)


### PR DESCRIPTION
which allows overview of coverage after make check or failure if a certain coverage isn't reached.

Summary of our conversation from https://github.com/krichter722/check-old/pull/1:

@brarcher:
- Adding these files to .gitignore might be better as a separate commit
- It may be better to check if the gcovr tool is installed and at the expected version in the configure script. Further, it may be useful to configure the coverage target as a configure option.
- Is there a way to perform this same check using gcov directly in a few lines, or is gcovr necessary?
Do you happen to know if gcovr is currently being distributed in a package for any linux distro?
- There is a configure options, --enable-gcov, which enables the necessary gcov flags.
Perhaps the coverage target should depend on the check target.

@krichter722: 
> There is a configure options, --enable-gcov, which enables the necessary gcov flags.

I don't understand what it does and it's not documented in `configure --help`.

> Perhaps the coverage target should depend on the check target.

That alone doesn't do it since the test compilation needs to be done with `CFLAGS='-g -O0 --coverage'`.

> Is there a way to perform this same check using gcov directly in a few lines, or is gcovr necessary?

As far as I understand (this is the first time I use `gcov` and `gcovr`) one needs to visualize the results anyway. Furthermore I added a customization of `gcovr` at https://github.com/krichter722/gcovr which allows `gcovr` to return a non-zero code if a certain coverage isn't met. I need to add a check that this customization is installed. Is that possible with `gcov` only?

> Adding these files to .gitignore might be better as a separate commit

Done.
