### PR TITLE
use printf binary directly when forming expected test output

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 In Development:
 # Mentioning Check 0.10.0 for now, to fix distcheck target until next release
 
+* Avoid issue in unit test output checking where a shell's built-in printf
+  command does not work properly, but the printf program itself is correct.
+
 * Emit only valid XML characters in XML logging (assumes ASCII encoding).
   Bug #103
 

--- a/tests/test_output_strings
+++ b/tests/test_output_strings
@@ -7,10 +7,15 @@
 # comparisons will work
 IFS="~"
 
+# Note that printf is invoked with 'env' so that the printf
+# program itself is used instead of a shell built-in. It
+# was observed on Lubuntu that the shell built-in printf
+# does not interpret hex escapes.
+
 ##################
 # stdout output
 ##################
-suite_output=`printf "Running suite(s): S1
+suite_output=`env printf "Running suite(s): S1
  S2
  XML escape \" ' < > & \x9 \x0AX\x08 tests"`
 
@@ -25,14 +30,14 @@ exp_minimal="$suite_output
 $exp_minimal_result"
 
 if [ $HAVE_FORK -eq 1 ]; then
-exp_normal_result=`printf "37%%: Checks: 8, Failures: 4, Errors: 1
+exp_normal_result=`env printf "37%%: Checks: 8, Failures: 4, Errors: 1
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
 ${SRCDIR}ex_output.c:46:E:Core:test_exit:0: (after this point) Early exit with return value 1
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
 ${SRCDIR}ex_output.c:78:F:description \" ' < > & \x9 \x0AX\x08 end:test_xml_esc_fail_msg:0: fail \" ' < > & \x9 \x0AX\x08 message"`
 else
-exp_normal_result=`printf "42%%: Checks: 7, Failures: 4, Errors: 0
+exp_normal_result=`env printf "42%%: Checks: 7, Failures: 4, Errors: 0
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
@@ -43,7 +48,7 @@ $exp_normal_result"
 
 
 if [ $HAVE_FORK -eq 1 ]; then
-exp_verbose_result=`printf "37%%: Checks: 8, Failures: 4, Errors: 1
+exp_verbose_result=`env printf "37%%: Checks: 8, Failures: 4, Errors: 1
 ${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
 ${SRCDIR}ex_output.c:46:E:Core:test_exit:0: (after this point) Early exit with return value 1
@@ -53,7 +58,7 @@ ${SRCDIR}ex_output.c:72:P:Core:test_loop:1: Passed
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
 ${SRCDIR}ex_output.c:78:F:description \" ' < > & \x9 \x0AX\x08 end:test_xml_esc_fail_msg:0: fail \" ' < > & \x9 \x0AX\x08 message"`
 else
-exp_verbose_result=`printf "42%%: Checks: 7, Failures: 4, Errors: 0
+exp_verbose_result=`env printf "42%%: Checks: 7, Failures: 4, Errors: 0
 ${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
 ${SRCDIR}ex_output.c:66:P:Core:test_pass2:0: Passed
@@ -66,7 +71,7 @@ exp_verbose="$suite_output
 $exp_verbose_result"
 
 if [ $HAVE_FORK -eq 1 ]; then
-exp_subunit=`printf "test: Core:test_pass
+exp_subunit=`env printf "test: Core:test_pass
 success: Core:test_pass
 test: Core:test_fail
 failure: Core:test_fail [
@@ -93,7 +98,7 @@ failure: description \" ' < > & \x9 \x0AX\x08 end:test_xml_esc_fail_msg [
 ${SRCDIR}ex_output.c:78: fail \" ' < > & \x9 \x0AX\x08 message
 ]"`
 else
-exp_subunit=`printf "test: Core:test_pass
+exp_subunit=`env printf "test: Core:test_pass
 success: Core:test_pass
 test: Core:test_fail
 failure: Core:test_fail [
@@ -121,7 +126,7 @@ fi
 # log output
 ##################
 if [ $HAVE_FORK -eq 1 ]; then
-expected_log_log=`printf "Running suite S1
+expected_log_log=`env printf "Running suite S1
 ${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
 ${SRCDIR}ex_output.c:46:E:Core:test_exit:0: (after this point) Early exit with return value 1
@@ -135,7 +140,7 @@ ${SRCDIR}ex_output.c:78:F:description \" ' < > & \x9 \x0AX\x08 end:test_xml_esc_
 Results for all suites run:
 37%%: Checks: 8, Failures: 4, Errors: 1"`
 else
-expected_log_log=`printf "Running suite S1
+expected_log_log=`env printf "Running suite S1
 ${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
 Running suite S2
@@ -293,7 +298,7 @@ fi
 # tap output
 ##################
 if [ $HAVE_FORK -eq 1 ]; then
-expected_normal_tap=`printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
+expected_normal_tap=`env printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
 not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
 not ok 3 - ${SRCDIR}ex_output.c:Core:test_exit: Early exit with return value 1
 ok 4 - ${SRCDIR}ex_output.c:Core:test_pass2: Passed
@@ -302,7 +307,7 @@ ok 6 - ${SRCDIR}ex_output.c:Core:test_loop: Passed
 not ok 7 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 2 failed
 not ok 8 - ${SRCDIR}ex_output.c:description \" ' < > & \x9 \x0AX\x08 end:test_xml_esc_fail_msg: fail \" ' < > & \x9 \x0AX\x08 message
 1..8"`
-expected_aborted_tap=`printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
+expected_aborted_tap=`env printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
 not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
 not ok 3 - ${SRCDIR}ex_output.c:Core:test_exit: Early exit with return value 1
 not ok 4 - ${SRCDIR}ex_output.c:Core:test_abort: Early exit with return value 1
@@ -313,7 +318,7 @@ not ok 8 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 2 failed
 not ok 9 - ${SRCDIR}ex_output.c:description \" ' < > & \x9 \x0AX\x08 end:test_xml_esc_fail_msg: fail \" ' < > & \x9 \x0AX\x08 message
 1..9"`
 else
-expected_normal_tap=`printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
+expected_normal_tap=`env printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
 not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
 ok 3 - ${SRCDIR}ex_output.c:Core:test_pass2: Passed
 not ok 4 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 0 failed


### PR DESCRIPTION
It was observed on Lubuntu that the sh built-in print does not
escape hex as expected. For example, the following is expected:

$ printf "hi\x9there\n"
hi	there
$

However, on Lubuntu the built-in printf command in sh produces the
following:

$ sh -c 'printf "hi\x9there\n'
hi\x9there
$

To avoid this, use the printf binary, which env will find and
invoke.