### PR TITLE
web: add Arch Linux installation information

### DIFF
--- a/web/install.html
+++ b/web/install.html
@@ -65,6 +65,7 @@ a package manager or compile from source on one's platform.
     <ul>
         <li><a href="#aptitude">Ubuntu/Debian via Aptitude</a></li>
         <li><a href="#yum">Fedora via Yum</a></li>
+        <li><a href="#pacman">Arch Linux via Pacman</a></li>
         <li><a href="#linuxsource">From Source</a></li>
     </ul>
     <li>GNU/Hurd</li>
@@ -114,7 +115,7 @@ $ sudo apt-get install check
 <a name="yum"></a>
 <h3>Fedora via Yum</h3>
 <p>
-Fedora both provides a Check package that can be installed. To install,
+Fedora provides a Check package that can be installed. To install,
 in a terminal, type:
 
 <div id="code"><pre class="command">
@@ -122,6 +123,18 @@ $ sudo yum install check
 </pre></div>
 </p>
 <br></br>
+
+
+<a name="pacman"></a>
+<h3>Arch Linux via Pacman</h3>
+<p>
+Arch Linux provides a Check package that can be installed. To install,
+in a terminal, type:
+
+<div id="code"><pre class="command">
+$ sudo pacman -S check
+</pre></div>
+</p>
 
 
 <a name="linuxsource"></a>


### PR DESCRIPTION
Add information to the installation webpage on how to install the program in Arch Linux using Pacman.

Also fix a small grammar error in the Fedora installation section.

When I was editing the file in Vim I noticed that it seemed to use "^M" to end lines. However, I am unfamiliar with this setup, and was unable to replicate this with some of the lines I modified. Please let me know how I can use this setup, and I will alter this pull request to use it.