### PR TITLE
Fix segfault when memmoving with negative/enormous n

### DIFF
--- a/src/check_pack.c
+++ b/src/check_pack.c
@@ -465,6 +465,8 @@ RcvMsg *punpack(FILE * fdes)
         /* Parse one message */
         n = get_result(buf, rmsg);
         nparse -= n;
+        if (nparse < 0)
+            eprintf("Error in call to get_result", __FILE__, __LINE__ - 3);
         /* Move remaining data in buffer to the beginning */
         memmove(buf, buf + n, nparse);
         /* If EOF has not been seen */


### PR DESCRIPTION
I observed a segmentation fault caused by trying to memmove by -15,
which makes 18446744073709551601 on my 64-bit platform after an argument
type promotion (from `int` into `size_t`).  In my case, this was connected
with filling up disk during the test facilitated by check, hence I derive
that the main issue was that not enough bytes for particular type of
message was actually read (and previously written, for that matter) and
because of this incompleteness, `get_result` happily consumed more bytes
than was read.

Additional debugging info at the point of segfault (`src/check_pack.c`):

```
468│         /* Move remaining data in buffer to the beginning */
469├>        memmove(buf, buf + n, nparse);
470│         /* If EOF has not been seen */
471│         if(nread > 0)
```

```
(gdb) p nparse
$1 = -15
(gdb) p	n
$2 = 23
(gdb) p	nread
$3 = 0
```
