### PR TITLE
Fix a type in configure.ac and conform to POSIX strsignal

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Committers:
     
 Contributors:
     Cesar Ballardini      (signals)
+    Anthony G. Basile     (fix configure.ac and strsignal())
     Friedrich Beckmann    (mingw and msvc port #1)
     Frank Bergmann        (WIN32 tmpfile workaround)
     Ross Burton           (pkg-config patch)

--- a/configure.ac
+++ b/configure.ac
@@ -293,7 +293,7 @@ HW_LIBRT_TIMERS
 
 # The following checks will replace missing functions from libcompat
 AC_REPLACE_FUNCS([alarm clock_gettime getline gettimeofday localtime_r strdup strsignal])
-AC_CHECK_DECLS([alarm, clock_gettime, getline gettimeofday, localtime_r, strdup, strsignal])
+AC_CHECK_DECLS([alarm, clock_gettime, getline, gettimeofday, localtime_r, strdup, strsignal])
 
 # The following checks are to only detect if the functions exist, but
 # not replace them

--- a/lib/libcompat.h
+++ b/lib/libcompat.h
@@ -133,7 +133,7 @@ CK_DLL_EXP char *strdup(const char *str);
 #endif /* !HAVE_DECL_STRDUP && HAVE__STRDUP */
 
 #if !HAVE_DECL_STRSIGNAL
-CK_DLL_EXP const char *strsignal(int sig);
+CK_DLL_EXP char *strsignal(int sig);
 #endif /* !HAVE_DECL_STRSIGNAL */
 
 /*

--- a/lib/strsignal.c
+++ b/lib/strsignal.c
@@ -20,7 +20,7 @@
 
 #include "libcompat.h"
 
-const char *strsignal(int sig)
+char *strsignal(int sig)
 {
     static char signame[40];
 


### PR DESCRIPTION
We fix to items here, as per the commit messages:

1)  configure.ac: fix typo.  AC_CHECK_DECLS requires commas between declaration.  The missing comma leads to HAVE_DECL_GETLINE_GETTIMEOFDAY which is non-sensical.

2) lib/strsignal.c: strsignal() should be not be declared const.  POSIX requires strsignal() to return a pointer to a char, not a pointer to a const char. (see man 3 strsignal)  On uClibc, and possibly other libcs, this causes problems with the correct declaration in string.h.
