### PR TITLE
Remove AC_CONFIG_AUX_DIR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,9 +19,6 @@ AC_CONFIG_MACRO_DIR([m4])
 # place where portability library functions are kept
 AC_CONFIG_LIBOBJ_DIR([lib])
 
-# place to put some extra build scripts installed
-AC_CONFIG_AUX_DIR([build-aux])
-
 # really severe build strictness
 AM_INIT_AUTOMAKE([-Wall gnits 1.11.2])
 # Change to using into-in-builddir in the future:


### PR DESCRIPTION
* autoconf 2.69
* automake 1.15

This is half an issue report and half a pull request.

The reason for this is that while autoreconf -fi works for most of the
needed scripts it doesn't copy ltmain.sh into build-aux which results
the following ./configure failure:

    configure.ac:137: error: required file 'build-aux/ltmain.sh' not found

This patch, which is a similar one I've provided to cloog[0] which
allows ./configure to at least complete.

I'm not sure what you think since obviously the directory was used for
some reason, likely to reduce top-level directory clutter, but this at
least works for me.

This will also likely solve https://github.com/libcheck/check/issues/34

0 https://groups.google.com/forum/?hl=en#!topic/cloog-development/28_M3Qk87-Q

Signed-off-by: Earnestly <zibeon@gmail.com>