### PR TITLE
remove AC_CONFIG_AUX_DIR in example

### DIFF
--- a/doc/example/configure.ac
+++ b/doc/example/configure.ac
@@ -8,9 +8,6 @@ AM_PROG_AR
 # unique source file --- primitive safety check 
 AC_CONFIG_SRCDIR([src/money.c])
 
-# place to put some extra build scripts installed
-AC_CONFIG_AUX_DIR([build-aux])
-
 # fairly severe build strictness
 # change foreign to gnu or gnits to comply with gnu standards
 AM_INIT_AUTOMAKE([-Wall -Werror foreign 1.11.2])


### PR DESCRIPTION
Potentially due to changes in automake and autoreconf

  https://www.gnu.org/software/automake/manual/html_node/Error-required-file-ltmain_002esh-not-found.html

the ltmain.sh script, generated by libtoolize, does not seem to honor the AC_CONFIG_AUX_DIR parameter. As a
result, the configure script will fail. To work around this, remove the AC_CONFIG_AUX_DIR option
to place all generated scripts into the current directory.

This should resolve https://github.com/libcheck/check/issues/34