### PR TITLE
Add test case where %n is passed into a ck_assert call

### DIFF
--- a/tests/check_check_master.c
+++ b/tests/check_check_master.c
@@ -104,6 +104,7 @@ static master_test_t master_tests[] = {
   { "Simple Tests", CK_FAILURE, "Assertion 'x >= y' failed: x == 2, y == 3" },
   { "Simple Tests", CK_FAILURE, "Assertion '1%d >= 3%f' failed: 1%d == 0, 3%f == 1" },
   { "Simple Tests", CK_PASS,    "Passed" },
+  { "Simple Tests", CK_FAILURE, "Assertion 'returnsZero(\"%n\") == 1' failed: returnsZero(\"%n\") == 0, 1 == 1" },
   { "Simple Tests", CK_FAILURE, "Assertion '\"test1\" == s' failed: \"test1\" == \"test1\", s == \"test2\"" },
   { "Simple Tests", CK_FAILURE, "Assertion 't != s' failed: t == \"test2\", s == \"test2\"" },
   { "Simple Tests", CK_FAILURE, "Assertion 's < s' failed: s == \"test1\", s == \"test1\"" },

--- a/tests/check_check_sub.c
+++ b/tests/check_check_sub.c
@@ -443,6 +443,20 @@ START_TEST(test_ck_assert_uint_expr)
   ck_assert_uint_eq(x, y);
 } END_TEST
 
+int returnsZero(const char* argument);
+int returnsZero(const char* argument)
+{
+    (void)argument;
+    return 0;
+}
+
+START_TEST(test_percent_n_escaped)
+{
+  /* If the %n is not escaped in the ck macro, then this results in a SEGFAULT */
+  record_failure_line_num(__LINE__);
+  ck_assert_int_eq(returnsZero("%n"), 1);
+} END_TEST
+
 START_TEST(test_ck_assert_str_eq)
 {
   const char *s = "test2";
@@ -1073,6 +1087,7 @@ Suite *make_sub_suite(void)
   tcase_add_test (tc_simple, test_ck_assert_uint_ge);
   tcase_add_test (tc_simple, test_ck_assert_uint_ge_with_mod);
   tcase_add_test (tc_simple, test_ck_assert_uint_expr);
+  tcase_add_test (tc_simple, test_percent_n_escaped);
   tcase_add_test (tc_simple, test_ck_assert_str_eq);
   tcase_add_test (tc_simple, test_ck_assert_str_ne);
   tcase_add_test (tc_simple, test_ck_assert_str_lt);


### PR DESCRIPTION
In the past it was possible to cause issues if arguments
were passed into ck_assert* macros which included %n.
Exist unit tests check for output format options, such as
%d and %f. No test existed for %n, which writes a value to
memory if used.

Ulrich Eckhardt observed that passing something with a %n in it
would result in issues running Check 0.9.10. Although the
issue is already resolved, this commit adds the test case mentioned in
Ulrich's GitHub issue: https://github.com/libcheck/check/issues/41