### PR TITLE
Dup tcase ignore

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -172,8 +172,11 @@ static void tcase_free(TCase * tc)
 
 void suite_add_tcase(Suite * s, TCase * tc)
 {
-    if(s == NULL || tc == NULL)
+    if(s == NULL || tc == NULL || check_list_contains(s->tclst, tc))
+    {
         return;
+    }
+
     check_list_add_end(s->tclst, tc);
 }
 

--- a/src/check.h.in
+++ b/src/check.h.in
@@ -145,7 +145,10 @@ CK_DLL_EXP Suite *CK_EXPORT suite_create(const char *name);
 CK_DLL_EXP int CK_EXPORT suite_tcase(Suite * s, const char *tcname);
 
 /**
- * Add a test case to a suite
+ * Add a test case to a suite.
+ *
+ * Note that if the TCase has already been added attempting
+ * to add it again will be ignored.
  *
  * @param s suite to add test case to
  * @param tc test case to add to suite

--- a/src/check_list.c
+++ b/src/check_list.c
@@ -140,3 +140,16 @@ void check_list_apply(List * lp, void (*fp) (void *))
         fp(check_list_val(lp));
 
 }
+
+bool check_list_contains(List * lp, void *val)
+{
+    for(check_list_front(lp); !check_list_at_end(lp); check_list_advance(lp))
+    {
+        if(check_list_val(lp) == val)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/check_list.h
+++ b/src/check_list.h
@@ -21,6 +21,8 @@
 #ifndef CHECK_LIST_H
 #define CHECK_LIST_H
 
+#include <stdbool.h>
+
 typedef struct List List;
 
 /* Create an empty list */
@@ -51,6 +53,9 @@ void check_list_advance(List * lp);
 void check_list_free(List * lp);
 
 void check_list_apply(List * lp, void (*fp) (void *));
+
+/* Return true if the list contains the value, false otherwise */
+bool check_list_contains(List * lp, void *val);
 
 
 #endif /* CHECK_LIST_H */

--- a/tests/check_check_master.c
+++ b/tests/check_check_master.c
@@ -165,16 +165,6 @@ static master_test_t master_tests[] = {
   { "User Double Timeout Tests", CK_ERROR,  "Test timeout expired" },
   { "User Double Timeout Tests", CK_ERROR,  "Test timeout expired" },
   
-  /* Default Timeout tests are run twice , see check_check_sub.c:make_sub_suite() */
-  { "Default Timeout Tests", CK_ERROR,  "Test timeout expired" },
-#ifdef HAVE_LIBRT
-  { "Default Timeout Tests", CK_PASS,   "Passed" },
-  { "Default Timeout Tests", CK_PASS,   "Passed" },
-#endif /* HAVE_LIBRT */
-  { "Default Timeout Tests", CK_PASS,   "Passed" },
-  { "Default Timeout Tests", CK_ERROR,  "Test timeout expired" },
-  { "Default Timeout Tests", CK_ERROR,  "Test timeout expired" },
-  
 #if HAVE_DECL_SETENV
   { "Environment Integer Timeout Scaling Tests", CK_ERROR,  "Test timeout expired" },
 #ifdef HAVE_LIBRT

--- a/tests/check_check_selective.c
+++ b/tests/check_check_selective.c
@@ -72,6 +72,12 @@ static void selective_setup (void)
   suite_add_tcase (s1, tc11);
   suite_add_tcase (s1, tc12);
   
+  /* This line intentionally attempts to add an already
+   * added test case twice, to ensure it is not added
+   * again. If it was added again, when the test cases
+   * are freed a double-free failure will occur. */
+  suite_add_tcase (s1, tc12);
+
   /*
    * Create a test suite 'suite2' with one test case 'test21'
    * containing two tests.

--- a/tests/check_check_sub.c
+++ b/tests/check_check_sub.c
@@ -1014,8 +1014,6 @@ Suite *make_sub_suite(void)
   suite_add_tcase (s, tc_timeout_usr_int);
   suite_add_tcase (s, tc_timeout_usr_double);
 
-  /* Add a second time to make sure tcase_set_timeout doesn't contaminate it. */
-  suite_add_tcase (s, tc_timeout_default);
 #if HAVE_DECL_SETENV
   suite_add_tcase (s, tc_timeout_env_scale_int);
   suite_add_tcase (s, tc_timeout_env_scale_double);

--- a/tests/check_list.c
+++ b/tests/check_list.c
@@ -164,6 +164,31 @@ START_TEST(test_list_abuse)
 }
 END_TEST
 
+START_TEST(test_contains)
+{
+    List *lp = check_list_create();
+
+    char otherData[] = "other";
+    char goalData[] = "goal";
+
+    ck_assert_msg (check_list_contains(lp, goalData) == false,
+                       "The goal data should not be in the list yet");
+
+    int index;
+    for(index = 0; index < 10; index++)
+    {
+        check_list_add_end (lp, otherData);
+        ck_assert_msg (check_list_contains(lp, goalData) == false,
+                   "The goal data should not be in the list yet");
+    }
+
+    check_list_add_end (lp, goalData);
+    ck_assert_msg (check_list_contains(lp, goalData) ,
+                       "The goal data should be in the list");
+
+    check_list_free(lp);
+}
+END_TEST
 
 Suite *make_list_suite (void)
 {
@@ -179,6 +204,7 @@ Suite *make_list_suite (void)
   tcase_add_test (tc, test_add_front_and_next);
   tcase_add_test (tc, test_add_a_bunch);
   tcase_add_test (tc, test_list_abuse);
+  tcase_add_test (tc, test_contains);
 
   return s;
 }


### PR DESCRIPTION
It was possible to add a test case to a suite more than once. When the suite is freed later on the test case is freed twice, causing a double free error.
    
Although is likely a bug from the test writer, this change allows Check to disallow double additions to prevent double freeing a test case.

https://github.com/libcheck/check/issues/50