### PR TITLE
Do not report failure line numbers if file not setup

### DIFF
--- a/tests/check_check_master.c
+++ b/tests/check_check_master.c
@@ -614,6 +614,18 @@ void record_failure_line_num(int linenum)
     exit(1);
   }
 
+  if(line_num_failures == NULL)
+  {
+    /* 
+     * The file may not be setup. This may be because some of the tests
+     * are being reused outside of the master suite. This is OK.
+     * If the master suite runs and does not find line numbers it will
+     * fail as expected.
+     */
+     fprintf(stderr, "Line number file not setup, not reporting test failure     line: %s", string);
+     return;
+  }
+
   written = fwrite(string, 1, to_write, line_num_failures);
   if(written != to_write)
   {


### PR DESCRIPTION
When running the master suite failure line numbers are written to
a file. Usually this is fine. However, the check_mem_leak.c test
re-uses the same tests. As a result, every time a failure is hit
a SEGV occurs because the file is never setup.

The memory leak test does not check against the line numbers,
so omitting these are fine. This fix prevents lots of SEGV
failures when running check_mem_leak.c under valgrind.