### PR TITLE
Make TAP test report compatible with standard

### DIFF
--- a/src/check_impl.h
+++ b/src/check_impl.h
@@ -127,6 +127,7 @@ struct SRunner
     enum fork_status fstat;     /* controls if suites are forked or not
                                    NOTE: Don't use this value directly,
                                    instead use srunner_fork_status */
+    int num_current_run_tests;
 };
 
 

--- a/src/check_log.c
+++ b/src/check_log.c
@@ -351,12 +351,11 @@ void tap_lfun(SRunner * sr CK_ATTRIBUTE_UNUSED, FILE * file,
             num_tests_run = 0;
             break;
         case CLENDLOG_SR:
-            /* Output the test plan as the last line */
-            fprintf(file, "1..%d\n", num_tests_run);
-            fflush(file);
             break;
         case CLSTART_SR:
-            break;
+			fprintf(file, "1..%d\n", sr->num_current_run_tests);
+			fflush(file);
+			break;
         case CLSTART_S:
             break;
         case CLEND_SR:

--- a/src/check_run.c
+++ b/src/check_run.c
@@ -160,6 +160,72 @@ static void srunner_run_end(SRunner * sr,
     set_fork_status(CK_FORK);
 }
 
+static int srunner_get_num_run_tests(List *slst, const char *sname,
+		const char *tcname, const char *include_tags, const char *exclude_tags)
+{
+    List *include_tag_lst;
+    List *exclude_tag_lst;
+    TCase *tc;
+    TF *tfun;
+    List *tcl, *tfl;
+
+    int count = 0;
+
+    include_tag_lst = tag_string_to_list(include_tags);
+    exclude_tag_lst = tag_string_to_list(exclude_tags);
+
+    for(check_list_front(slst); !check_list_at_end(slst);
+         check_list_advance(slst))
+    {
+		Suite *s = (Suite *)check_list_val(slst);
+
+		if(((sname != NULL) && (strcmp(sname, s->name) != 0))
+		|| ((tcname != NULL) && (!suite_tcase(s, tcname))))
+			continue;
+
+        tcl = s->tclst;
+		for(check_list_front(tcl); !check_list_at_end(tcl);
+			check_list_advance(tcl))
+		{
+			tc = (TCase *)check_list_val(tcl);
+
+			if (include_tags != NULL)
+			{
+				if (!tcase_matching_tag(tc, include_tag_lst))
+				{
+					continue;
+				}
+			}
+
+			if (exclude_tags != NULL)
+			{
+				if (tcase_matching_tag(tc, exclude_tag_lst))
+				{
+					continue;
+				}
+			}
+
+			tfl = tc->tflst;
+
+			for(check_list_front(tfl); !check_list_at_end(tfl);
+				check_list_advance(tfl))
+			{
+				int i;
+				tfun = (TF *)check_list_val(tfl);
+				for(i = tfun->loop_start; i < tfun->loop_end; i++)
+					count++;
+			}
+		}
+     }
+
+    check_list_apply(include_tag_lst, free);
+    check_list_apply(exclude_tag_lst, free);
+    check_list_free(include_tag_lst);
+    check_list_free(exclude_tag_lst);
+
+    return count;
+}
+
 static void srunner_iterate_suites(SRunner * sr,
                                    const char *sname, const char *tcname,
 				   const char *include_tags,
@@ -811,6 +877,8 @@ void srunner_run_tagged(SRunner * sr, const char *sname, const char *tcname,
     sigterm_new_action.sa_handler = sig_handler;
     sigaction(SIGTERM, &sigterm_new_action, &sigterm_old_action);
 #endif /* HAVE_SIGACTION && HAVE_FORK */
+    sr->num_current_run_tests = srunner_get_num_run_tests(sr->slst, sname,
+               tcname, include_tags, exclude_tags);
     srunner_run_init(sr, print_mode);
     srunner_iterate_suites(sr, sname, tcname, include_tags, exclude_tags,
 			   print_mode);

--- a/tests/test_output_strings
+++ b/tests/test_output_strings
@@ -297,16 +297,17 @@ fi
 # tap output
 ##################
 if [ $HAVE_FORK -eq 1 ]; then
-expected_normal_tap=`printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
+expected_normal_tap=`printf "1..8
+ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
 not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
 not ok 3 - ${SRCDIR}ex_output.c:Core:test_exit: Early exit with return value 1
 ok 4 - ${SRCDIR}ex_output.c:Core:test_pass2: Passed
 not ok 5 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 0 failed
 ok 6 - ${SRCDIR}ex_output.c:Core:test_loop: Passed
 not ok 7 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 2 failed
-not ok 8 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message
-1..8"`
-expected_aborted_tap=`printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
+not ok 8 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message"`
+expected_aborted_tap=`printf "1..9
+ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
 not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
 not ok 3 - ${SRCDIR}ex_output.c:Core:test_exit: Early exit with return value 1
 not ok 4 - ${SRCDIR}ex_output.c:Core:test_abort: Early exit with return value 1
@@ -314,17 +315,16 @@ ok 5 - ${SRCDIR}ex_output.c:Core:test_pass2: Passed
 not ok 6 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 0 failed
 ok 7 - ${SRCDIR}ex_output.c:Core:test_loop: Passed
 not ok 8 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 2 failed
-not ok 9 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message
-1..9"`
+not ok 9 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message"`
 else
-expected_normal_tap=`printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
+expected_normal_tap=`printf "1..7
+ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
 not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
 ok 3 - ${SRCDIR}ex_output.c:Core:test_pass2: Passed
 not ok 4 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 0 failed
 ok 5 - ${SRCDIR}ex_output.c:Core:test_loop: Passed
 not ok 6 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 2 failed
-not ok 7 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message
-1..7"`
+not ok 7 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message"`
 # When fork() is unavailable, one of the tests
 # will invoke exit() which will terminate the
 # unit testing program. In that case, the tap


### PR DESCRIPTION
Instead of printing 1...N at the end, we print at the beginning of the test, in order to comply to TAP specification.