### PR TITLE
clock_gettime.c: Use __APPLE__ instead of __MACH__

### DIFF
--- a/lib/clock_gettime.c
+++ b/lib/clock_gettime.c
@@ -20,7 +20,7 @@
 
 #include "libcompat.h"
 
-#ifdef __MACH__
+#ifdef __APPLE__
 #include <mach/clock.h>
 #include <mach/mach.h>
 #include <mach/mach_time.h>
@@ -35,8 +35,9 @@
 int clock_gettime(clockid_t clk_id CK_ATTRIBUTE_UNUSED, struct timespec *ts)
 {
 
-#ifdef __MACH__
-    /* OS X does not have clock_gettime, use mach_absolute_time */
+#ifdef __APPLE__
+    /* Some versions of macOS and iOS do not have clock_gettime, use
+     * mach_absolute_time */
 
     static mach_timebase_info_data_t sTimebaseInfo;
     uint64_t rawTime;


### PR DESCRIPTION
Hurd also defines `__MACH__`, but it does not have `mach_absolute_time` or `mach/clock.h`. Use the more strict `__APPLE__` instead.