### PR TITLE
Skip OSX/CMake test combo until failures fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,14 @@ addons:
     packages:
       - texinfo
 
+matrix:
+  exclude:
+  # There have been sporadic unit test failures with
+  # timeout tests on OSX using CMake. Until these are
+  # resolved, skipping these tests.
+  - os: osx
+    env: USE_CMAKE=YES
+
 script:
   - mkdir build
   - cd build


### PR DESCRIPTION
There have been sporadic unit test failures with timeout tests on OSX using CMake. 
Until these are resolved, skipping these tests.