### PR TITLE
Allow tests to be checked with Valgrind via ctest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,8 @@ endif(WIN32)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_vars.in
   ${CMAKE_CURRENT_BINARY_DIR}/test_vars)
 
+include(CTest)
+
 set(CHECK_CHECK_SOURCES
   check_check_exit.c
   check_check_fixture.c


### PR DESCRIPTION
If some internal tests have segmentation faults those could be located with "ctest -D ExperimentalMemCheck".