### PR TITLE
Use ctest on VC builds to run unit tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,4 +58,4 @@ test_script:
   # run unit tests
   - echo Running unit tests...
   - if %platform%==msvc nmake test VERBOSE=1 CTEST_OUTPUT_ON_FAILURE=TRUE
-  - if %platform%==vs msbuild "RUN_TESTS.vcxproj"
+  - if %platform%==vs ctest --extra-verbose -C Release


### PR DESCRIPTION
msbuild was running the unit tests, but if a failure was hit
the output of the unit tests was not printed. As a result,
there was no indication as to what actually failed in a given
unit test program. Using ctest (part of CMake) should
output the unit test program's output for better failure
diagnosis.