### PR TITLE
Add regular expressions support for internal tests checking

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,7 +115,7 @@ Contributors:
     Jan Pokorny
         (corner case segfault fix)
     Dotsenko Andrey Nikolaevich
-        (floating point comparison macros ck_assert_floating_*)
+        (floating point comparison macros)
 
 Anybody who has contributed code to Check or Check's build system is
 considered an author.  Submit a pull request of this file or send

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ ck_check_include_file("sys/types.h" HAVE_SYS_TYPES_H)
 ck_check_include_file("errno.h" HAVE_ERRNO_H)
 ck_check_include_file("inttypes.h" HAVE_INTTYPES_H)
 ck_check_include_file("limits.h" HAVE_LIMITS_H)
+ck_check_include_file("regex.h" HAVE_REGEX_H)
 ck_check_include_file("signal.h" HAVE_SIGNAL_H)
 ck_check_include_file("stdarg.h" HAVE_STDARG_H)
 ck_check_include_file("stdint.h" HAVE_STDINT_H)
@@ -114,6 +115,10 @@ check_function_exists(strdup HAVE_DECL_STRDUP)
 check_function_exists(strsignal HAVE_DECL_STRSIGNAL)
 check_function_exists(_getpid HAVE__GETPID)
 check_function_exists(_strdup HAVE__STRDUP)
+if (HAVE_REGEX_H)
+  check_function_exists(regcomp HAVE_REGCOMP)
+  check_function_exists(regexec HAVE_REGEXEC)
+endif()
 
 # printf related checks
 check_function_exists(snprintf HAVE_SNPRINTF_FUNCTION)
@@ -148,6 +153,13 @@ else(HAVE_MKSTEMP)
     add_definitions(-DHAVE_MKSTEMP=0)
     set(HAVE_MKSTEMP 0)
 endif(HAVE_MKSTEMP)
+
+if(HAVE_REGEX_H AND HAVE_REGCOMP AND HAVE_REGEXEC)
+    add_definitions(-DHAVE_REGEX=1)
+    set(HAVE_REGEX 1)
+    add_definitions(-DENABLE_REGEX=1)
+    set(ENABLE_REGEX 1)
+endif()
 
 
 ###############################################################################
@@ -299,7 +311,6 @@ else(HAVE_SUBUNIT)
     set(ENABLE_SUBUNIT 0)
     add_definitions(-DENABLE_SUBUNIT=0)
 endif (HAVE_SUBUNIT)
-
 
 ###############################################################################
 # Generate "config.h" from "cmake/config.h.cmake"

--- a/configure.ac
+++ b/configure.ac
@@ -246,6 +246,24 @@ AC_DEFINE_UNQUOTED(ENABLE_SUBUNIT, $ENABLE_SUBUNIT, [Subunit protocol result out
 
 AM_CONDITIONAL(SUBUNIT, test x"$enable_subunit" != "xfalse")
 
+# Check for POSIX regular expressions support.
+AC_CHECK_HEADERS([regex.h], HAVE_REGEX_H=1, HAVE_REGEX_H=0)
+
+if test "x$HAVE_REGEX_H" = "x1"; then
+    AC_CHECK_FUNCS([regcomp regexec], HAVE_REGEX=1, HAVE_REGEX=0)
+else
+    HAVE_REGEX=0
+fi
+AC_SUBST(HAVE_REGEX)
+AC_DEFINE_UNQUOTED(HAVE_REGEX, $HAVE_REGEX, "Regular expressions are supported")
+
+if test "x$HAVE_REGEX" = "x1"; then
+    ENABLE_REGEX="1"
+else
+    ENABLE_REGEX="0"
+fi
+AC_SUBST(ENABLE_REGEX)
+AC_DEFINE_UNQUOTED(ENABLE_REGEX, $ENABLE_REGEX, "Regular expressions are supported and enabled")
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
@@ -401,5 +419,12 @@ else
     result="no"
 fi
 echo "timeout unit tests ................... $result"
+
+if test "x0" = x"$ENABLE_REGEX"; then
+    result="no"
+else
+    result="yes"
+fi
+echo "POSIX regular expressions ............ $result"
 
 echo "=========================================="

--- a/tests/check_check_master.c
+++ b/tests/check_check_master.c
@@ -149,8 +149,13 @@ static master_test_t master_tests[] = {
   { "Simple Tests", "test_ck_assert_float_infinite_with_mod", CK_FAILURE, CK_MSG_TEXT, "Assertion '2%d is infinite' failed: 2%d == 0" },
   { "Simple Tests", "test_ck_assert_float_nan", CK_FAILURE, CK_MSG_TEXT, "Assertion 'x is NaN' failed: x == inf" },
   { "Simple Tests", "test_ck_assert_float_nan_with_mod", CK_FAILURE, CK_MSG_TEXT, "Assertion '2%d is NaN' failed: 2%d == 0" },
+#if ENABLE_REGEX
+  { "Simple Tests", "test_ck_assert_float_nonnan", CK_FAILURE, CK_MSG_REGEXP, "^Assertion 'x is not NaN' failed: x == -?nan$" },
+  { "Simple Tests", "test_ck_assert_float_nonnan_with_mod", CK_FAILURE, CK_MSG_REGEXP, "^Assertion '\\(2%s\\)\\*x is not NaN' failed: \\(2%s\\)\\*x == -?nan$" },
+#else
   { "Simple Tests", "test_ck_assert_float_nonnan", CK_PASS, CK_MSG_TEXT, "Passed" },
   { "Simple Tests", "test_ck_assert_float_nonnan_with_mod", CK_PASS, CK_MSG_TEXT, "Passed" },
+#endif
   { "Simple Tests", "test_ck_assert_float_nan_and_inf_with_expr", CK_PASS, CK_MSG_TEXT, "Passed" },
   /* End of tests on float macros */
   /* Tests on double macros */
@@ -184,8 +189,13 @@ static master_test_t master_tests[] = {
   { "Simple Tests", "test_ck_assert_double_infinite_with_mod", CK_FAILURE, CK_MSG_TEXT, "Assertion '2%d is infinite' failed: 2%d == 0" },
   { "Simple Tests", "test_ck_assert_double_nan", CK_FAILURE, CK_MSG_TEXT, "Assertion 'x is NaN' failed: x == inf" },
   { "Simple Tests", "test_ck_assert_double_nan_with_mod", CK_FAILURE, CK_MSG_TEXT, "Assertion '2%d is NaN' failed: 2%d == 0" },
+#if ENABLE_REGEX
+  { "Simple Tests", "test_ck_assert_double_nonnan", CK_FAILURE, CK_MSG_REGEXP, "^Assertion 'x is not NaN' failed: x == -?nan$" },
+  { "Simple Tests", "test_ck_assert_double_nonnan_with_mod", CK_FAILURE, CK_MSG_REGEXP, "^Assertion '\\(2%s\\)\\*x is not NaN' failed: \\(2%s\\)\\*x == -?nan$" },
+#else
   { "Simple Tests", "test_ck_assert_double_nonnan", CK_PASS, CK_MSG_TEXT, "Passed" },
   { "Simple Tests", "test_ck_assert_double_nonnan_with_mod", CK_PASS, CK_MSG_TEXT, "Passed" },
+#endif
   { "Simple Tests", "test_ck_assert_double_nan_and_inf_with_expr", CK_PASS, CK_MSG_TEXT, "Passed" },
   /* End of tests on double macros */
   /* Tests on long double macros */
@@ -219,8 +229,13 @@ static master_test_t master_tests[] = {
   { "Simple Tests", "test_ck_assert_ldouble_infinite_with_mod", CK_FAILURE, CK_MSG_TEXT, "Assertion '2%d is infinite' failed: 2%d == 0" },
   { "Simple Tests", "test_ck_assert_ldouble_nan", CK_FAILURE, CK_MSG_TEXT, "Assertion 'x is NaN' failed: x == inf" },
   { "Simple Tests", "test_ck_assert_ldouble_nan_with_mod", CK_FAILURE, CK_MSG_TEXT, "Assertion '2%d is NaN' failed: 2%d == 0" },
+#if ENABLE_REGEX
+  { "Simple Tests", "test_ck_assert_ldouble_nonnan", CK_FAILURE, CK_MSG_REGEXP, "^Assertion 'x is not NaN' failed: x == -?nan$" },
+  { "Simple Tests", "test_ck_assert_ldouble_nonnan_with_mod", CK_FAILURE, CK_MSG_REGEXP, "^Assertion '\\(2%s\\)\\*x is not NaN' failed: \\(2%s\\)\\*x == -?nan$" },
+#else
   { "Simple Tests", "test_ck_assert_ldouble_nonnan", CK_PASS, CK_MSG_TEXT, "Passed" },
   { "Simple Tests", "test_ck_assert_ldouble_nonnan_with_mod", CK_PASS, CK_MSG_TEXT, "Passed" },
+#endif
   { "Simple Tests", "test_ck_assert_ldouble_nan_and_inf_with_expr", CK_PASS, CK_MSG_TEXT, "Passed" },
   /* End of tests on long double macros */
   { "Simple Tests", "test_percent_n_escaped", CK_FAILURE, CK_MSG_TEXT, "Assertion 'returnsZero(\"%n\") == 1' failed: returnsZero(\"%n\") == 0, 1 == 1" },

--- a/tests/check_check_sub.c
+++ b/tests/check_check_sub.c
@@ -913,10 +913,14 @@ START_TEST(test_ck_assert_float_nonnan)
 {
   record_test_name(tcase_name());
 
-  float t = 1.0f;
   float x = 0.0f;
   ck_assert_float_nonnan(x);
-  // TODO: test with 0.0/0.0 and platform specific output.
+#if ENABLE_REGEX
+  float t = 1.0f;
+  x = 0.0f / (1.0f - t);
+  record_failure_line_num(__LINE__);
+  ck_assert_float_nonnan(x);
+#endif
 }
 END_TEST
 
@@ -926,7 +930,12 @@ START_TEST(test_ck_assert_float_nonnan_with_mod)
 
   int s = 2;
   ck_assert_float_nonnan(2%s);
-  // TODO: test with 0.0/0.0 and platform specific output.
+#if ENABLE_REGEX
+  float t = 1.0f;
+  float x = 0.0f / (1.0f - t);
+  record_failure_line_num(__LINE__);
+  ck_assert_float_nonnan((2%s)*x);
+#endif
 }
 END_TEST
 
@@ -1383,10 +1392,14 @@ START_TEST(test_ck_assert_double_nonnan)
 {
   record_test_name(tcase_name());
 
-  double t = 1;
   double x = 0;
   ck_assert_double_nonnan(x);
-  // TODO: test with 0.0/0.0 and platform specific output.
+#if ENABLE_REGEX
+  double t = 1;
+  x = 0.0 / (1.0 - t);
+  record_failure_line_num(__LINE__);
+  ck_assert_double_nonnan(x);
+#endif
 }
 END_TEST
 
@@ -1396,7 +1409,12 @@ START_TEST(test_ck_assert_double_nonnan_with_mod)
 
   int s = 2;
   ck_assert_double_nonnan(2%s);
-  // TODO: test with 0.0/0.0 and platform specific output.
+#if ENABLE_REGEX
+  double t = 1.0;
+  double x = 0.0 / (1.0 - t);
+  record_failure_line_num(__LINE__);
+  ck_assert_double_nonnan((2%s)*x);
+#endif
 }
 END_TEST
 
@@ -1855,10 +1873,14 @@ START_TEST(test_ck_assert_ldouble_nonnan)
 {
   record_test_name(tcase_name());
 
-  long double t = 1.0l;
   long double x = 0.0l;
   ck_assert_ldouble_nonnan(x);
-  // TODO: test with 0.0/0.0 and platform specific output.
+#if ENABLE_REGEX
+  long double t = 1.0l;
+  x = 0.0l / (1.0l - t);
+  record_failure_line_num(__LINE__);
+  ck_assert_ldouble_nonnan(x);
+#endif
 }
 END_TEST
 
@@ -1868,7 +1890,12 @@ START_TEST(test_ck_assert_ldouble_nonnan_with_mod)
 
   int s = 2;
   ck_assert_ldouble_nonnan(2%s);
-  // TODO: test with 0.0/0.0 and platform specific output.
+#if ENABLE_REGEX
+  long double t = 1.0l;
+  long double x = 0.0l / (1.0l - t);
+  record_failure_line_num(__LINE__);
+  ck_assert_ldouble_nonnan((2%s)*x);
+#endif
 }
 END_TEST
 


### PR DESCRIPTION
At the moment it uses POSIX regular expressions. I do not know if windows has those, so if not, I'll change them to pcre. Tests will show.