### PR TITLE
Always emit unit test output for CMake on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,5 @@ script:
   - if [ $USE_CMAKE == 'NO' ] ; then pushd .. ; autoreconf -i ; popd; fi
   - if [ $USE_CMAKE == 'NO' ] ; then ../configure ; fi
   - make
-  - if [ $USE_CMAKE == 'YES' ] ; then CTEST_OUTPUT_ON_FAILURE=1 make test ; fi
+  - if [ $USE_CMAKE == 'YES' ] ; then ctest -V ; fi
   - if [ $USE_CMAKE == 'NO' ] ; then make check ; fi


### PR DESCRIPTION
Internally "make test" invokes ctest, and passing the -V flag will print the stdout from the unit tests.