### PR TITLE
Remove usage of "lg" in printf format

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,5 +78,5 @@ test_script:
   # Unit tests on Cygwin currently do not all pass
   #- if %platform%==cygwin bash -c "make check || cat tests/test-suite.log && false"
   # check_check does not work on MinGW
-  #- if %platform%==mingw32 tests\check_check.exe
+  - if %platform%==mingw32 tests\check_check.exe
   - if %platform%==mingw64msys bash -c "tests/check_check"

--- a/src/check.h.in
+++ b/src/check.h.in
@@ -961,7 +961,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_float_nonnan(X) _ck_assert_floating_nonnan(X, float, "l")
+#define ck_assert_float_nonnan(X) _ck_assert_floating_nonnan(X, float, "")
 
 /**
  * Check two double precision floating point numbers to determine if X == Y
@@ -975,7 +975,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_eq(X, Y) _ck_assert_floating(X, ==, Y, double, "l")
+#define ck_assert_double_eq(X, Y) _ck_assert_floating(X, ==, Y, double, "")
 /**
  * Check two double precision floating point numbers to determine if X != Y
  *
@@ -988,7 +988,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_ne(X, Y) _ck_assert_floating(X, !=, Y, double, "l")
+#define ck_assert_double_ne(X, Y) _ck_assert_floating(X, !=, Y, double, "")
 /**
  * Check two double precision floating point numbers to determine if X < Y
  *
@@ -1001,7 +1001,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_lt(X, Y) _ck_assert_floating(X, <, Y, double, "l")
+#define ck_assert_double_lt(X, Y) _ck_assert_floating(X, <, Y, double, "")
 /**
  * Check two double precision floating point numbers to determine if X <= Y
  *
@@ -1014,7 +1014,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_le(X, Y) _ck_assert_floating(X, <=, Y, double, "l")
+#define ck_assert_double_le(X, Y) _ck_assert_floating(X, <=, Y, double, "")
 /**
  * Check two double precision floating point numbers to determine if X > Y
  *
@@ -1027,7 +1027,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_gt(X, Y) _ck_assert_floating(X, >, Y, double, "l")
+#define ck_assert_double_gt(X, Y) _ck_assert_floating(X, >, Y, double, "")
 /**
  * Check two double precision floating point numbers to determine if X >= Y
  *
@@ -1040,7 +1040,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_ge(X, Y) _ck_assert_floating(X, >=, Y, double, "l")
+#define ck_assert_double_ge(X, Y) _ck_assert_floating(X, >=, Y, double, "")
 
 /**
  * Check two double precision floating point numbers to determine if X≈Y
@@ -1056,7 +1056,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_eq_tol(X, Y, T)  _ck_assert_floating_absdiff_op_tol(X, Y, <, T, double, "l")
+#define ck_assert_double_eq_tol(X, Y, T)  _ck_assert_floating_absdiff_op_tol(X, Y, <, T, double, "")
 
 /**
  * Check two double precision floating point numbers to determine if not X≈Y
@@ -1072,7 +1072,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_ne_tol(X, Y, T) _ck_assert_floating_absdiff_op_tol(X, Y, >=, T, double, "l")
+#define ck_assert_double_ne_tol(X, Y, T) _ck_assert_floating_absdiff_op_tol(X, Y, >=, T, double, "")
 
 /**
  * Check two double precision floating point numbers to determine if X>≈Y
@@ -1088,7 +1088,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_ge_tol(X, Y, T) _ck_assert_floating_op_tol(X, >, Y, T, -1, double, "l")
+#define ck_assert_double_ge_tol(X, Y, T) _ck_assert_floating_op_tol(X, >, Y, T, -1, double, "")
 
 /**
  * Check two double precision floating point numbers to determine if X<≈Y
@@ -1104,7 +1104,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_le_tol(X, Y, T) _ck_assert_floating_op_tol(X, <, Y, T, 1, double, "l")
+#define ck_assert_double_le_tol(X, Y, T) _ck_assert_floating_op_tol(X, <, Y, T, 1, double, "")
 
 /**
  * Check that a double precision floating point number is finite; i.e. is
@@ -1118,7 +1118,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_finite(X) _ck_assert_floating_finite(X, double, "l")
+#define ck_assert_double_finite(X) _ck_assert_floating_finite(X, double, "")
 
 /**
  * Check that a double precision floating point number is infinite,
@@ -1132,7 +1132,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_infinite(X) _ck_assert_floating_infinite(X, double, "l")
+#define ck_assert_double_infinite(X) _ck_assert_floating_infinite(X, double, "")
 
 /**
  * Check that a double precision floating point number
@@ -1146,7 +1146,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_nan(X) _ck_assert_floating_nan(X, double, "l")
+#define ck_assert_double_nan(X) _ck_assert_floating_nan(X, double, "")
 
 /**
  * Check that a double precision floating point number is
@@ -1160,7 +1160,7 @@ do { \
  *
  * @since 0.11.0
  */
-#define ck_assert_double_nonnan(X) _ck_assert_floating_nonnan(X, double, "l")
+#define ck_assert_double_nonnan(X) _ck_assert_floating_nonnan(X, double, "")
 
 /** 
  * Check two double precision floating point numbers to determine if X == Y


### PR DESCRIPTION
MinGW on Windows does not "lg". The reason is that MinGW mixes
GCC and the MSVC runtime. For GCC a long double is either
96-bit or 128-bit type for long double on x86 or x64 targets
(see http://gcc.gnu.org/onlinedocs/gcc/i386-and-x86_002d64-Options.html).
However, MSVC uses a 64-bit type
(see http://msdn.microsoft.com/en-us/library/9cx8xs15.aspx).
That means for MSVC "double" and "long double" are the same.
    
Because of this mismatch, the "l" in "lg", which is safely ignored
on Linux and BSD systems is not safely ignored in MSVC systems
where GCC is used to compile. This issue does not arise when using
VS compiler on Windows.

Credit for explaining this problem goes here: http://stackoverflow.com/questions/7134547/gcc-printf-and-long-double-leads-to-wrong-output-c-type-conversion-messes-u

https://github.com/libcheck/check/issues/101