### PR TITLE
Enable all unit test programs for Cygwin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,6 +77,5 @@ test_script:
   - if %platform%==vs ctest --extra-verbose -C Release
   # Unit tests on Cygwin currently do not all pass
   #- if %platform%==cygwin bash -c "make check || cat tests/test-suite.log && false"
-  # check_check does not work on MinGW
   - if %platform%==mingw32 tests\check_check.exe
   - if %platform%==mingw64msys bash -c "tests/check_check"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,9 @@ test_script:
   - echo Running unit tests...
   - if %platform%==msvc nmake test VERBOSE=1 CTEST_OUTPUT_ON_FAILURE=TRUE
   - if %platform%==vs ctest --extra-verbose -C Release
-  # Unit tests on Cygwin currently do not all pass
-  #- if %platform%==cygwin bash -c "make check || cat tests/test-suite.log && false"
+  - if %platform%==cygwin bash -c "make check"
   - if %platform%==mingw32 tests\check_check.exe
   - if %platform%==mingw64msys bash -c "tests/check_check"
+
+on_finish:
+  - if %platform%==cygwin bash -c "cat tests/test-suite.log || true"

--- a/tests/check_check_fixture.c
+++ b/tests/check_check_fixture.c
@@ -300,6 +300,11 @@ START_TEST(test_ch_setup_pass_nofork)
 }
 END_TEST
 
+/* This test currently does not work on Cygwin, as it results in a
+ * SIGSEGV instead of a SIGFPE. However, a simple program that installs
+ * a SIGFPE handler then raise(SIGFPE) works as expected. Further
+ * investigation is necessary. */
+#if !defined(__CYGWIN__)
 /*
  * This test will fail without fork, as it results in a checked
  * fixture raising a signal, which terminates the test runner early.
@@ -350,6 +355,7 @@ START_TEST(test_ch_setup_sig)
   free(tr);
 }
 END_TEST
+#endif /* !defined(__CYGWIN__) */
 
 static void sub_ch_setup_dual_1(void)
 {
@@ -487,7 +493,11 @@ START_TEST(test_ch_teardown_fail_nofork)
 }
 END_TEST
 
-
+/* This test currently does not work on Cygwin, as it results in a
+ * SIGSEGV instead of a SIGFPE. However, a simple program that installs
+ * a SIGFPE handler then raise(SIGFPE) works as expected. Further
+ * investigation is necessary. */
+#if !defined(__CYGWIN__)
 /*
  * This test will fail without fork, as it results in a checked
  * fixture raising a signal, which terminates the test runner early.
@@ -539,6 +549,7 @@ START_TEST(test_ch_teardown_sig)
   free(tr);
 }
 END_TEST
+#endif /* !defined(__CYGWIN__) */
 
 /* Teardowns are run in reverse order */
 static void sub_ch_teardown_dual_1(void)
@@ -631,11 +642,15 @@ Suite *make_fixture_suite (void)
   tcase_add_test(tc,test_ch_setup_fail_nofork);
   tcase_add_test(tc,test_ch_setup_fail_nofork_2);
   tcase_add_test(tc,test_ch_setup_pass_nofork);
+#if !defined(__CYGWIN__)
   tcase_add_test(tc,test_ch_setup_sig);
+#endif /* !defined(__CYGWIN__) */
   tcase_add_test(tc,test_ch_setup_two_setups_fork);
   tcase_add_test(tc,test_ch_teardown_fail);
   tcase_add_test(tc,test_ch_teardown_fail_nofork);
+#if !defined(__CYGWIN__)
   tcase_add_test(tc,test_ch_teardown_sig);
+#endif /* !defined(__CYGWIN__) */
   tcase_add_test(tc,test_ch_teardown_two_teardowns_fork);
 #endif
 

--- a/tests/check_check_master.c
+++ b/tests/check_check_master.c
@@ -248,9 +248,11 @@ static master_test_t master_tests[] = {
   { "Signal Tests", "test_segv", CK_ERROR,   signal_11_8_str },
   { "Signal Tests", "test_non_signal_8", CK_FAILURE, "Early exit with return value 0" },
   { "Signal Tests", "test_fail_unless", CK_FAILURE, "Early exit with return value 1" },
+#if !defined(__CYGWIN__)
   { "Signal Tests", "test_fpe", CK_ERROR,   signal_8_str },
   { "Signal Tests", "test_mark_point", CK_ERROR,   signal_8_str },
-#endif
+#endif /* !defined(__CYGWIN__) */
+#endif /* HAVE_FORK */
 
 #if TIMEOUT_TESTS_ENABLED && defined(HAVE_FORK) && HAVE_FORK==1
 #if HAVE_DECL_SETENV

--- a/tests/check_check_sub.c
+++ b/tests/check_check_sub.c
@@ -2272,6 +2272,11 @@ START_TEST(test_segv)
 }
 END_TEST
 
+/* This test currently does not work on Cygwin, as it results in a
+ * SIGSEGV instead of a SIGFPE. However, a simple program that installs
+ * a SIGFPE handler then raise(SIGFPE) works as expected. Further
+ * investigation is necessary. */
+#if !defined(__CYGWIN__)
 START_TEST(test_fpe)
 {
   record_test_name(tcase_name());
@@ -2279,6 +2284,7 @@ START_TEST(test_fpe)
   raise (SIGFPE);
 }
 END_TEST
+#endif /* !defined(__CYGWIN__) */
 
 /*
  * This test is to be used when the test is expected to throw signal 8,
@@ -2295,6 +2301,11 @@ END_TEST
 /* TODO:
    unit test running the same suite in succession */
 
+/* This test currently does not work on Cygwin, as it results in a
+ * SIGSEGV instead of a SIGFPE. However, a simple program that installs
+ * a SIGFPE handler then raise(SIGFPE) works as expected. Further
+ * investigation is necessary. */
+#if !defined(__CYGWIN__)
 START_TEST(test_mark_point)
 {
   int i;
@@ -2307,7 +2318,9 @@ START_TEST(test_mark_point)
   ck_abort_msg("Shouldn't reach here");
 }
 END_TEST
-#endif
+#endif /* !defined(__CYGWIN__) */
+
+#endif /* HAVE_FORK */
 
 #if TIMEOUT_TESTS_ENABLED && defined(HAVE_FORK) && HAVE_FORK == 1
 START_TEST(test_eternal_fail)
@@ -2959,8 +2972,10 @@ Suite *make_sub_suite(void)
   tcase_add_test_raise_signal (tc_signal, test_segv, 8);  /* error */
   tcase_add_test_raise_signal (tc_signal, test_non_signal_8, 8);  /* fail  */
   tcase_add_test_raise_signal (tc_signal, test_fail_unless, 8);  /* fail  */
+#if !defined(__CYGWIN__)
   tcase_add_test (tc_signal, test_fpe);
   tcase_add_test (tc_signal, test_mark_point);
+#endif /* !defined(__CYGWIN__) */
 #endif /* HAVE_FORK */
 
 #if TIMEOUT_TESTS_ENABLED && defined(HAVE_FORK) && HAVE_FORK == 1


### PR DESCRIPTION
Cygwin on Windows 2012 (i.e. AppVeyor) does not pass the tests which raise(SIGFPE). However, the same tests pass on Windows 7 and Cygwin. Until this is resolved, the remaining tests should be run to prevent regressions. This pull request enables the remaining unit test programs while preventing the raise(SIGFPE) tests from running only on Cygwin.