### PR TITLE
Fix the Money build example using CMake

### DIFF
--- a/doc/example/tests/CMakeLists.txt
+++ b/doc/example/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src)
 
 find_package(Check REQUIRED)
 include_directories(${CHECK_INCLUDE_DIRS})
+link_directories(${CHECK_LIBRARY_DIRS})
 
 set(TEST_SOURCES
   check_money.c


### PR DESCRIPTION
I downloaded the 0.11.0 tarball, installed **check** through **autotools** on OSX 10.11 and followed the tutorial for [Setting Up the Money Build Using CMake](https://libcheck.github.io/check/doc/check_html/check_3.html#Setting-Up-the-Money-Build-Using-CMake). I used the CMake example in the source directory, but when I got to the *make* step I got the following error:

```
$ make
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/viktor/Downloads/check-0.11.0/doc/example/build
[ 33%] Built target money
[ 66%] Built target main
[ 83%] Linking C executable check_money
ld: library not found for -lcheck
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [tests/check_money] Error 1
make[1]: *** [tests/CMakeFiles/check_money.dir/all] Error 2
```

So I included the library directory, so this error does not appear. I don't think this would break something on a Windows machine, but I didn't test.


PS:
I noticed that when I install check through compiling the source with autotools (or using homebrew) then the CMake related files are not in the example directory, which probably is on purpose.
