### PR TITLE
Bail on error if cannot create pipe file

### DIFF
--- a/src/check_msg.c
+++ b/src/check_msg.c
@@ -315,11 +315,19 @@ static void setup_pipe(void)
     if(send_file1 == NULL)
     {
         send_file1 = open_tmp_file(&send_file1_name);
+        if(send_file1 == NULL)
+        {
+            eprintf("Unable to create temporary file for communication; may not have permissions to do so", __FILE__, __LINE__ -3);
+        }
         return;
     }
     if(send_file2 == NULL)
     {
         send_file2 = open_tmp_file(&send_file2_name);
+        if(send_file2 == NULL)
+        {
+            eprintf("Unable to create temporary file for communication; may not have permissions to do so", __FILE__, __LINE__ -3);
+        }
         return;
     }
     eprintf("Only one nesting of suite runs supported", __FILE__, __LINE__);


### PR DESCRIPTION
There have been cases where a test will fail with "No messaging setup". This is believed to be
a permissions issue, where the test process is unable to create a file in the folder selected
for temporary files. To make this error more explicit, if creating a temporary file fails bail.