### PR TITLE
Update 'no messaging setup' message

### DIFF
--- a/src/check_msg.c
+++ b/src/check_msg.c
@@ -77,7 +77,7 @@ static FILE *get_pipe(void)
         return send_file1;
     }
 
-    eprintf("No messaging setup", __FILE__, __LINE__);
+    eprintf("Unable to report test progress or a failure; was an ck_assert or ck_abort function called while not running tests?", __FILE__, __LINE__);
 
     return NULL;
 }


### PR DESCRIPTION
It was found that if a ck_assert() or ck_abort() call was made when not running a test
with srunner_run() that the current process would attempt to report a test
failure to the process which started the test, of which none exists. As a result,
finding no pipe file setup, the process aborts. This is all due to an API usage
mistake, as ck_assert* and ck_abort() should not be called outside of a
test or setup/teardown function.

To make it more clear that if one hits this it is a API usage issue, changing the
failure message which is reported.