### PR TITLE
Define pid_t in check.h for Windows

### DIFF
--- a/src/check.h.in
+++ b/src/check.h.in
@@ -63,6 +63,11 @@ CK_CPPSTART
 
 #include <sys/types.h>
 
+#if _MSC_VER
+/* define pid_t for Windows, as it is needed later */
+#define pid_t int
+#endif /* _MSC_VER */
+
 /*
  * Used to create the linker script for hiding lib-local symbols. Shall
  * be put directly in front of the exported symbol.

--- a/tests/ex_output.c
+++ b/tests/ex_output.c
@@ -18,7 +18,7 @@
  * MA 02110-1301, USA.
  */
 
-#include "../lib/libcompat.h"
+
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
pid_t is not defined for Windows, so check.h cannot be included directly. To avoid this, define pid_t in check.h for Windows.

To test that this is working, removing the libcompat.h include in ex_output.c, which only uses external API calls and should not need anything from libcomapt.h.

https://github.com/libcheck/check/issues/78