### PR TITLE
Fix invalid prototype for tcase_name(void)

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -349,7 +349,7 @@ void tcase_fn_start(const char *fname, const char *file,
     current_test_name = fname;
 }
 
-const char* tcase_name()
+const char* tcase_name(void)
 {
 	return current_test_name;
 }

--- a/src/check.h.in
+++ b/src/check.h.in
@@ -390,7 +390,7 @@ CK_DLL_EXP void CK_EXPORT tcase_fn_start(const char *fname, const char *file,
  *
  * @since 0.11.0
  */
-CK_DLL_EXP const char* CK_EXPORT tcase_name();
+CK_DLL_EXP const char* CK_EXPORT tcase_name(void);
 
 /**
  * Start a unit test with START_TEST(unit_name), end with END_TEST.


### PR DESCRIPTION
The existing prototype in check.h is `const char* tcase_name()`. This causes issues on platforms that use strict prototype checking, e.g. the latest clang compiler with -Wstrict-prototypes ('this function declaration is not a prototype [-Werror,-Wstrict-prototypes]').

Changing to `const char* tcase_name(void)` resolves this issue.