### PR TITLE
[WIP] Improve reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.autosave
 *.swp
 *.swap
+/tags
 
 # Generated binaries
 *.o

--- a/src/check.c
+++ b/src/check.c
@@ -531,6 +531,7 @@ static void tr_init(TestResult * tr)
     tr->rtype = CK_TEST_RESULT_INVALID;
     tr->msg = NULL;
     tr->file = NULL;
+    tr->sname = NULL;
     tr->tcname = NULL;
     tr->tname = NULL;
     tr->duration = -1;

--- a/src/check_impl.h
+++ b/src/check_impl.h
@@ -82,6 +82,7 @@ struct TestResult
     int line;                   /* Line number where the test occurred */
     int iter;                   /* The iteration value for looping tests */
     int duration;               /* duration of this test in microseconds */
+    const char *sname;          /* Suite that generated the result */
     const char *tcname;         /* Test case that generated the result */
     const char *tname;          /* Test that generated the result */
     char *msg;                  /* Failure message */

--- a/src/check_run.c
+++ b/src/check_run.c
@@ -60,8 +60,8 @@ static void srunner_run_init(SRunner * sr, enum print_output print_mode);
 static void srunner_run_end(SRunner * sr, enum print_output print_mode);
 static void srunner_iterate_suites(SRunner * sr,
                                    const char *sname, const char *tcname,
-				   const char *include_tags,
-				   const char *exclude_tags,
+                                   const char *include_tags,
+                                   const char *exclude_tags,
                                    enum print_output print_mode);
 static void srunner_iterate_tcase_tfuns(SRunner * sr, TCase * tc);
 static void srunner_add_failure(SRunner * sr, TestResult * tf);
@@ -162,8 +162,8 @@ static void srunner_run_end(SRunner * sr,
 
 static void srunner_iterate_suites(SRunner * sr,
                                    const char *sname, const char *tcname,
-				   const char *include_tags,
-				   const char *exclude_tags,
+                                   const char *include_tags,
+                                   const char *exclude_tags,
                                    enum print_output CK_ATTRIBUTE_UNUSED
                                    print_mode)
 {
@@ -200,20 +200,20 @@ static void srunner_iterate_suites(SRunner * sr,
             {
                 continue;
             }
-	    if (include_tags != NULL)
-	    {
-		if (!tcase_matching_tag(tc, include_tag_lst))
-		{
-		    continue;
-		}
-	    }
-	    if (exclude_tags != NULL)
-	    {
-		if (tcase_matching_tag(tc, exclude_tag_lst))
-		{
-		    continue;
-		}
-	    }
+            if (include_tags != NULL)
+            {
+                if (!tcase_matching_tag(tc, include_tag_lst))
+                {
+                    continue;
+                }
+            }
+            if (exclude_tags != NULL)
+            {
+                if (tcase_matching_tag(tc, exclude_tag_lst))
+                {
+                    continue;
+                }
+            }
 
             srunner_run_tcase(sr, tc);
         }
@@ -768,8 +768,8 @@ void srunner_run_all(SRunner * sr, enum print_output print_mode)
 }
 
 void srunner_run_tagged(SRunner * sr, const char *sname, const char *tcname,
-			const char *include_tags, const char *exclude_tags,
-			enum print_output print_mode)
+                        const char *include_tags, const char *exclude_tags,
+                        enum print_output print_mode)
 {
 #if defined(HAVE_SIGACTION) && defined(HAVE_FORK)
     static struct sigaction sigalarm_old_action;
@@ -783,11 +783,11 @@ void srunner_run_tagged(SRunner * sr, const char *sname, const char *tcname,
     if(!tcname)
         tcname = getenv("CK_RUN_CASE");
     if(!sname)
-	sname = getenv("CK_RUN_SUITE");
+        sname = getenv("CK_RUN_SUITE");
     if(!include_tags)
-	include_tags = getenv("CK_INCLUDE_TAGS");
+        include_tags = getenv("CK_INCLUDE_TAGS");
     if(!exclude_tags)
-	exclude_tags = getenv("CK_EXCLUDE_TAGS");
+        exclude_tags = getenv("CK_EXCLUDE_TAGS");
 
     if(sr == NULL)
         return;
@@ -811,7 +811,7 @@ void srunner_run_tagged(SRunner * sr, const char *sname, const char *tcname,
 #endif /* HAVE_SIGACTION && HAVE_FORK */
     srunner_run_init(sr, print_mode);
     srunner_iterate_suites(sr, sname, tcname, include_tags, exclude_tags,
-			   print_mode);
+                           print_mode);
     srunner_run_end(sr, print_mode);
 #if defined(HAVE_SIGACTION) && defined(HAVE_FORK)
     sigaction(SIGALRM, &sigalarm_old_action, NULL);

--- a/src/check_str.c
+++ b/src/check_str.c
@@ -39,10 +39,10 @@ char *tr_str(TestResult * tr)
 
     exact_msg = (tr->rtype == CK_ERROR) ? "(after this point) " : "";
 
-    rstr = ck_strdup_printf("%s:%d:%s:%s:%s:%d: %s%s",
+    rstr = ck_strdup_printf("%s:%d:%s:%s:%s:%s:%d: %s%s",
                             tr->file, tr->line,
-                            tr_type_str(tr), tr->tcname, tr->tname, tr->iter,
-                            exact_msg, tr->msg);
+                            tr_type_str(tr), tr->sname, tr->tcname, tr->tname,
+                            tr->iter, exact_msg, tr->msg);
 
     return rstr;
 }

--- a/tests/check_check_fixture.c
+++ b/tests/check_check_fixture.c
@@ -83,7 +83,7 @@ START_TEST(test_setup_failure_msg)
 {
   TestResult **tra;
   char *trm;
-  const char *trmexp = "check_check_fixture.c:36:S:Fix Sub:unchecked_setup:0: Test failure in fixture";
+  const char *trmexp = "check_check_fixture.c:36:S:Fix Sub:Fix Sub:unchecked_setup:0: Test failure in fixture";
 
   tra = srunner_failures(fixture_sr);
   trm = tr_str(tra[0]);
@@ -212,7 +212,7 @@ START_TEST(test_ch_setup_fail)
   trm = tr_str(tr[0]);
    /* Search for check_check_fixture.c:150 if this fails. */
   if (strstr(trm,
-	     "check_check_fixture.c:150:S:Setup Fail:test_sub_fail:0: Failed setup")
+	     "check_check_fixture.c:150:S:Setup Fail:Setup Fail:test_sub_fail:0: Failed setup")
       == 0) {
     snprintf(errm, sizeof(errm),
 	     "Bad failed checked setup tr msg (%s)", trm);
@@ -342,7 +342,7 @@ START_TEST(test_ch_setup_sig)
   trm = tr_str(tr[0]);
 
   if (strstr(trm,
-	     "check_check_fixture.c:160:S:Setup Sig:test_sub_fail:0: "
+	     "check_check_fixture.c:160:S:Setup Sig:Setup Sig:test_sub_fail:0: "
 	     "(after this point) Received signal 8")
       == 0) {
     snprintf(errm, sizeof(errm),
@@ -435,7 +435,7 @@ START_TEST(test_ch_teardown_fail)
   trm = tr_str(tr[0]);
 
   if (strstr(trm,
-	     "check_check_fixture.c:155:S:Teardown Fail:test_sub_pass:0: Failed teardown")
+	     "check_check_fixture.c:155:S:Teardown Fail:Teardown Fail:test_sub_pass:0: Failed teardown")
       == 0) {
     snprintf(errm, sizeof(errm),
 	     "Bad failed checked teardown tr msg (%s)", trm);
@@ -481,7 +481,7 @@ START_TEST(test_ch_teardown_fail_nofork)
   trm = tr_str(tr[0]);
 
   if (strstr(trm,
-	     "check_check_fixture.c:155:S:Teardown Fail No Fork:test_sub_pass:0: Failed teardown")
+	     "check_check_fixture.c:155:S:Teardown Fail No Fork:Teardown Fail No Fork:test_sub_pass:0: Failed teardown")
       == 0) {
     snprintf(errm, sizeof(errm),
 	     "Bad failed checked teardown tr msg (%s)", trm);
@@ -536,7 +536,7 @@ START_TEST(test_ch_teardown_sig)
   trm = tr_str(tr[0]);
 
   if (strstr(trm,
-	     "check_check_fixture.c:166:S:Teardown Sig:test_sub_pass:0: "
+	     "check_check_fixture.c:166:S:Teardown Sig:Teardown Sig:test_sub_pass:0: "
 	     "(after this point) Received signal 8")
       == 0) {
     snprintf(errm, sizeof(errm),

--- a/tests/test_check_nofork_teardown.sh
+++ b/tests/test_check_nofork_teardown.sh
@@ -4,7 +4,7 @@
 
 expected="Running suite(s): bug-99
 0%: Checks: 1, Failures: 1, Errors: 0
-${SRCDIR}check_nofork_teardown.c:56:F:tc:will_fail:0: Assertion '0' failed"
+${SRCDIR}check_nofork_teardown.c:56:F:bug-99:tc:will_fail:0: Assertion '0' failed"
 
 actual=`./check_nofork_teardown${EXEEXT} | tr -d "\r"`
 if [ x"${expected}" = x"${actual}" ]; then

--- a/tests/test_output_strings
+++ b/tests/test_output_strings
@@ -30,17 +30,17 @@ $exp_minimal_result"
 
 if [ $HAVE_FORK -eq 1 ]; then
 exp_normal_result=`printf "37%%: Checks: 8, Failures: 4, Errors: 1
-${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
-${SRCDIR}ex_output.c:46:E:Core:test_exit:0: (after this point) Early exit with return value 1
-${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
-${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
-${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
+${SRCDIR}ex_output.c:37:F:S1:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:46:E:S1:Core:test_exit:0: (after this point) Early exit with return value 1
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:0: Iteration 0 failed
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:2: Iteration 2 failed
+${SRCDIR}ex_output.c:78:F:XML escape \" ' < > & $tab_nl_X_bs tests:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
 else
 exp_normal_result=`printf "42%%: Checks: 7, Failures: 4, Errors: 0
-${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
-${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
-${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
-${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
+${SRCDIR}ex_output.c:37:F:S1:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:72:F:S1:Core:test_loop:0: Iteration 0 failed
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:2: Iteration 2 failed
+${SRCDIR}ex_output.c:78:F:XML escape \" ' < > & $tab_nl_X_bs tests:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
 fi
 exp_normal="$suite_output
 $exp_normal_result"
@@ -48,23 +48,23 @@ $exp_normal_result"
 
 if [ $HAVE_FORK -eq 1 ]; then
 exp_verbose_result=`printf "37%%: Checks: 8, Failures: 4, Errors: 1
-${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
-${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
-${SRCDIR}ex_output.c:46:E:Core:test_exit:0: (after this point) Early exit with return value 1
-${SRCDIR}ex_output.c:66:P:Core:test_pass2:0: Passed
-${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
-${SRCDIR}ex_output.c:72:P:Core:test_loop:1: Passed
-${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
-${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
+${SRCDIR}ex_output.c:31:P:S1:Core:test_pass:0: Passed
+${SRCDIR}ex_output.c:37:F:S1:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:46:E:S1:Core:test_exit:0: (after this point) Early exit with return value 1
+${SRCDIR}ex_output.c:66:P:S2:Core:test_pass2:0: Passed
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:0: Iteration 0 failed
+${SRCDIR}ex_output.c:72:P:S2:Core:test_loop:1: Passed
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:2: Iteration 2 failed
+${SRCDIR}ex_output.c:78:F:XML escape \" ' < > & $tab_nl_X_bs tests:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
 else
 exp_verbose_result=`printf "42%%: Checks: 7, Failures: 4, Errors: 0
-${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
-${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
-${SRCDIR}ex_output.c:66:P:Core:test_pass2:0: Passed
-${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
-${SRCDIR}ex_output.c:72:P:Core:test_loop:1: Passed
-${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
-${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
+${SRCDIR}ex_output.c:31:P:S1:Core:test_pass:0: Passed
+${SRCDIR}ex_output.c:37:F:S1:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:66:P:S2:Core:test_pass2:0: Passed
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:0: Iteration 0 failed
+${SRCDIR}ex_output.c:72:P:S2:Core:test_loop:1: Passed
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:2: Iteration 2 failed
+${SRCDIR}ex_output.c:78:F:XML escape \" ' < > & $tab_nl_X_bs tests:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
 fi
 exp_verbose="$suite_output
 $exp_verbose_result"
@@ -126,29 +126,29 @@ fi
 ##################
 if [ $HAVE_FORK -eq 1 ]; then
 expected_log_log=`printf "Running suite S1
-${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
-${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
-${SRCDIR}ex_output.c:46:E:Core:test_exit:0: (after this point) Early exit with return value 1
+${SRCDIR}ex_output.c:31:P:S1:Core:test_pass:0: Passed
+${SRCDIR}ex_output.c:37:F:S1:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:46:E:S1:Core:test_exit:0: (after this point) Early exit with return value 1
 Running suite S2
-${SRCDIR}ex_output.c:66:P:Core:test_pass2:0: Passed
-${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
-${SRCDIR}ex_output.c:72:P:Core:test_loop:1: Passed
-${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
+${SRCDIR}ex_output.c:66:P:S2:Core:test_pass2:0: Passed
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:0: Iteration 0 failed
+${SRCDIR}ex_output.c:72:P:S2:Core:test_loop:1: Passed
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:2: Iteration 2 failed
 Running suite XML escape \" ' < > & $tab_nl_X_bs tests
-${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message
+${SRCDIR}ex_output.c:78:F:XML escape \" ' < > & $tab_nl_X_bs tests:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message
 Results for all suites run:
 37%%: Checks: 8, Failures: 4, Errors: 1"`
 else
 expected_log_log=`printf "Running suite S1
-${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
-${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:31:P:S1:Core:test_pass:0: Passed
+${SRCDIR}ex_output.c:37:F:S1:Core:test_fail:0: Failure
 Running suite S2
-${SRCDIR}ex_output.c:66:P:Core:test_pass2:0: Passed
-${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
-${SRCDIR}ex_output.c:72:P:Core:test_loop:1: Passed
-${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
+${SRCDIR}ex_output.c:66:P:S2:Core:test_pass2:0: Passed
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:0: Iteration 0 failed
+${SRCDIR}ex_output.c:72:P:S2:Core:test_loop:1: Passed
+${SRCDIR}ex_output.c:72:F:S2:Core:test_loop:2: Iteration 2 failed
 Running suite XML escape \" ' < > & $tab_nl_X_bs tests
-${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message
+${SRCDIR}ex_output.c:78:F:XML escape \" ' < > & $tab_nl_X_bs tests:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message
 Results for all suites run:
 42%%: Checks: 7, Failures: 4, Errors: 0"`
 fi


### PR DESCRIPTION
Features discussed in #166.
- [ ] Prepend suite name while reporting tests.
- [ ] Create test results for test cases, separate from individual tests.
- [ ] Report errors in unchecked setups in test case results. Also report subsequent tests as failed due to failure in test case setups.
- [ ] Unchecked test case teardowns need to override the fork mode to CK_NOFORK, so that reported failures do not kill the unit test program.
- [ ] Report errors in unchecked teardowns in test case results. Tests included in tests cases will report their own results, independent from failure of unchecked teardowns.
- [ ] Update documentation to reflect changes.
