### PR TITLE
Set CMAKE_SOURCE_DIR for AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -109,7 +109,7 @@ before_build:
   # the MinGW builds
   - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
   - if %platform%==msvc call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"
-  - if %platform%==msvc cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=%P%
+  - if %platform%==msvc cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX=%P% -DCMAKE_SOURCE_DIR=%P%
   - if %platform%==vs (
       set "makecommand=Visual Studio"
     )
@@ -154,12 +154,12 @@ before_build:
   - if %arch%==ARM (
       set "makecommand=%makecommand% ARM"
     )
-  - if %platform%==vs cmake -G "%makecommand%" -DCMAKE_INSTALL_PREFIX=%P%
+  - if %platform%==vs cmake -G "%makecommand%" -DCMAKE_INSTALL_PREFIX=%P% -DCMAKE_SOURCE_DIR=%P%
   - if %platform%==cygwin set PATH=C:\cygwin\bin;%PATH%
   - if %platform%==cygwin bash -c "autoreconf -i"
   - if %platform%==cygwin bash -c "./configure"
   - if %platform%==mingw32 set PATH=C:\MinGW\bin;%PATH%
-  - if %platform%==mingw32 cmake -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=%P%
+  - if %platform%==mingw32 cmake -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=%P% -DCMAKE_SOURCE_DIR=%P%
   - if %platform%==mingw64msys set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%
   - if %platform%==mingw64msys bash -c "autoreconf -i"
   - if %platform%==mingw64msys bash -c "./configure"


### PR DESCRIPTION
Prior to CMake 3.13.3 if the source and bin directories were not specified it
was assumed to be the current working directory. Starting in 3.13.3 this case
results in an error. Neither was being specified in the AppVeyor builds. These
builds are now failing, and it is assumed to be related to a CMake upgrade.

Specifying the source dir should avoid the issue.

Reference: https://gitlab.kitware.com/cmake/cmake/issues/18817