### PR TITLE
Improve import to CMake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,12 @@ set(MEMORY_LEAKING_TESTS_ENABLED 1)
 set(CMAKE_BUILD_TYPE Debug)
 
 ###############################################################################
+# Adhere strictly to old ANSI C89 / ISO C90 standard
+set(CMAKE_C_STANDARD 90)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)          # Use GNU extensions and POSIX standard
+
+###############################################################################
 # Option
 option(CHECK_ENABLE_TESTS
   "Enable the compilation and running of Check's unit tests" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ extract_version(configure.ac CHECK_MAJOR_VERSION)
 extract_version(configure.ac CHECK_MINOR_VERSION)
 extract_version(configure.ac CHECK_MICRO_VERSION)
 
-set(CHECK_VERSION
+set(check_VERSION
   "${CHECK_MAJOR_VERSION}.${CHECK_MINOR_VERSION}.${CHECK_MICRO_VERSION}")
 
 set(MEMORY_LEAKING_TESTS_ENABLED 1)
@@ -366,3 +366,37 @@ if (CHECK_ENABLE_TESTS)
       COMMAND sh ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_set_max_msg_size.sh)
   endif(UNIX OR MINGW OR MSYS)
 endif()
+
+###############################################################################
+# Export project, prepare a config and config-version files
+set(LIB_INSTALL_DIR lib CACHE FILEPATH "lib INSTALL DIR")
+set(EXPORT_NAME ${CMAKE_PROJECT_NAME})
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${EXPORT_NAME}-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${EXPORT_NAME}-config.cmake
+    INSTALL_DESTINATION ${LIB_INSTALL_DIR}/${EXPORT_NAME}/cmake
+)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${EXPORT_NAME}-config-version.cmake
+    VERSION ${check_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+export(EXPORT check-targets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/check-targets.cmake"
+    NAMESPACE Check::
+)
+
+install(EXPORT check-targets
+    NAMESPACE Check::
+    FILE check-targets.cmake
+    DESTINATION lib/cmake/${EXPORT_NAME}
+)
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/${EXPORT_NAME}-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/${EXPORT_NAME}-config-version.cmake"
+    DESTINATION lib/cmake/${EXPORT_NAME}
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,7 @@ else(HAVE_SUBUNIT)
 endif (HAVE_SUBUNIT)
 
 ###############################################################################
-# Generate "config.h" from "cmake/config.h.cmake"
+# Generate "config.h" from "cmake/config.h.in"
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})

--- a/cmake/check-config.cmake.in
+++ b/cmake/check-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+include("${CMAKE_CURRENT_LIST_DIR}/check-targets.cmake")
+

--- a/doc/check.texi
+++ b/doc/check.texi
@@ -2241,6 +2241,30 @@ Officially CMake is supported only for Windows.
 Documentation for using CMake is forthcoming. In the meantime, look
 at the example CMake project in Check's @file{doc/examples} directory.
 
+If you are using CMake version 3 or above, importing Check into your project
+is easier than in earlier versions. If you have installed Check
+as a CMake library, you should have the following files:
+
+@verbatim
+${INSTALL_PREFIX}/lib/cmake/check/check-config.cmake and
+${INSTALL_PREFIX}/lib/cmake/check/check-config-version.cmake and
+@end verbatim
+
+If you haven't installed Check into a system directory, you have to tell
+your CMake build how to find it:
+
+@verbatim
+cmake -Dcheck_ROOT=${INSTALL_PREFIX}
+
+Then use Check in your @file{CMakeLists.txt} like this:
+
+@verbatim
+find_package(check <check_version if wanted> REQUIRED CONFIG)
+
+add_executable(myproj.test myproj.test.c)
+target_link_libraries(myproj.test Check::check)
+add_test(NAME MyProj COMMAND myproj.test)
+@end verbatim
 
 
 @node Conclusion and References, Environment Variable Reference, Supported Build Systems, Top

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,10 +62,11 @@ if(MSVC)
 endif (MSVC)
 
 install(TARGETS check 
-  EXPORT check
+  EXPORT check-targets
+  INCLUDES DESTINATION include
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
 
 install(FILES ${CMAKE_BINARY_DIR}/src/check.h DESTINATION include)
-install(EXPORT check DESTINATION cmake)
+


### PR DESCRIPTION
CMake 3 and above support a better way to import other projects. Instead of variables having target libraries (filenames) and include directories, you can import targets. This is more convenient and easier. Commit 3451a76 contains an example of how this is done.