### PR TITLE
Change type from signed int to size_t

### DIFF
--- a/src/check_pack.c
+++ b/src/check_pack.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <stddef.h>
 
 #include "check.h"
 #include "check_error.h"
@@ -319,8 +320,7 @@ static void ppack_cleanup(void *mutex)
 void ppack(FILE * fdes, enum ck_msg_type type, CheckMsg * msg)
 {
     char *buf = NULL;
-    int n;
-    ssize_t r;
+    size_t n, r;
 
     n = pack(type, &buf, msg);
     /* Keep it on the safe side to not send too much data. */


### PR DESCRIPTION
check_pack.c:327:10: warning: comparison between signed and unsigned
integer expressions [-Wsign-compare]
       if(n > get_max_msg_size())
        ^

Signed-off-by: Mikko Koivunalho <mikko.koivunalho@iki.fi>