### PR TITLE
Fix int main() function to "int main(void)"

### DIFF
--- a/tests/check_mem_leaks.c
+++ b/tests/check_mem_leaks.c
@@ -32,7 +32,7 @@
 #include "config.h"
 #include "check_check.h"
 
-int main ()
+int main (void)
 {
     int n;
     SRunner *sr;


### PR DESCRIPTION
check_mem_leaks.c:35:5: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 int main ()
     ^~~~