### PR TITLE
Fix bug with CMake project variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,7 +376,7 @@ endif()
 ###############################################################################
 # Export project, prepare a config and config-version files
 set(LIB_INSTALL_DIR lib CACHE FILEPATH "lib INSTALL DIR")
-set(EXPORT_NAME ${CMAKE_PROJECT_NAME})
+set(EXPORT_NAME ${PROJECT_NAME})
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${EXPORT_NAME}-config.cmake.in


### PR DESCRIPTION
"
I tried to embed the check source code into my project in a "3rdparty" folder. Turns out that the build fails because of the usage of CMAKE_PROJECT_NAME instead of PROJECT_NAME in the check CMakeLists.txt

CMAKE_PROJECT_NAME is the name of the topmost project, that is in my case my own project.
Changing to PROJECT_NAME worked fine.
"

https://github.com/libcheck/check/issues/194

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>