### PR TITLE
Add checkmk to cmake

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -121,6 +121,8 @@ Contributors:
          test source code compliance to C89/C90 standard,
          substitution functions for floating point functions missing
          in older C standard libraries)
+    Mikko Koivunalho
+        (Improved CMake build)
 
 Anybody who has contributed code to Check or Check's build system is
 considered an author.  Submit a pull request of this file or send

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/check_stdint.h DESTINATION include)
 # Subdirectories
 add_subdirectory(lib)
 add_subdirectory(src)
+add_subdirectory(checkmk)
 
 ###############################################################################
 # Unit tests

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ include_HEADERS = check_stdint.h
 
 EXTRA_DIST = check.pc.in $(m4data_DATA) xml/check_unittest.xslt \
 	CMakeLists.txt src/CMakeLists.txt tests/CMakeLists.txt lib/CMakeLists.txt \
+	checkmk/CMakeLists.txt \
 	cmake
 
 ## install docs

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
-In Development:
-# Mentioning Check 0.12.0 for now, to fix distcheck target until next release
+Planned Release Check 0.13.0
+
+* missing <unistd.h> in some files
+  Issue #196 and Issue #186 (GitHub)
+
+* Add checkmk to CMake build.
 
 
 Fri Oct 20, 2017: Released Check 0.12.0

--- a/checkmk/CMakeLists.txt
+++ b/checkmk/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(conf_file "checkmk.in" FILEPATH)
+set(configure_input "Generated from ${conf_file} by configure.")
+find_program(AWK_PATH awk)
+
+configure_file(checkmk.in checkmk @ONLY)
+
+file(COPY doc/checkmk.1 DESTINATION man/man1)
+
+option(INSTALL_CHECKMK "Install checkmk" ON)
+include(GNUInstallDirs)
+if(INSTALL_CHECKMK)
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/checkmk
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+  )
+  install(
+    DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/man/man1
+    DESTINATION share/man
+  )
+endif(INSTALL_CHECKMK)
+
+

--- a/configure.ac
+++ b/configure.ac
@@ -4,9 +4,9 @@
 # Prelude.
 AC_PREREQ([2.59])
 
-AC_INIT([Check], [0.12.0], [check-devel at lists dot sourceforge dot net])
+AC_INIT([Check], [0.13.0], [check-devel at lists dot sourceforge dot net])
 CHECK_MAJOR_VERSION=0
-CHECK_MINOR_VERSION=12
+CHECK_MINOR_VERSION=13
 CHECK_MICRO_VERSION=0
 CHECK_VERSION=$CHECK_MAJOR_VERSION.$CHECK_MINOR_VERSION.$CHECK_MICRO_VERSION
 


### PR DESCRIPTION
Until now the checkmk utility was not built when CMake build was used. Installation is done as below:
${CMAKE_INSTALL_PREFIX}/bin/checkmk
${CMAKE_INSTALL_PREFIX}/share/man/man1
${CMAKE_INSTALL_PREFIX}/share/man/man1/checkmk.1

Permissions (binary):
OWNER_READ, OWNER_WRITE, OWNER_EXECUTE,
GROUP_READ, GROUP_EXECUTE,
WORLD_READ, WORLD_EXECUTE