### PR TITLE
Fix missing macro undefinition

### DIFF
--- a/src/check.h.in
+++ b/src/check.h.in
@@ -74,6 +74,8 @@ CK_CPPSTART
 #define CK_ATTRIBUTE_NORETURN
 #endif /* GCC 2.5 */
 
+#undef GCC_VERSION_AT_LEAST
+
 #include <sys/types.h>
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
If we don't undefine the macro, it will enter the user's namespace.
This macro is only for our internal use.
Otherwise it would have the "CK_" prefix.

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>