### PR TITLE
Fix c standard to c99

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT
 include(GNUInstallDirs)
 
 ###############################################################################
-# Adhere strictly to old ANSI C89 / ISO C90 standard
-set(CMAKE_C_STANDARD 90)
+# Follow ISO C99 standard
+set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)          # Use GNU extensions and POSIX standard
 

--- a/src/check_pack.c
+++ b/src/check_pack.c
@@ -62,7 +62,7 @@ static size_t get_max_msg_size(void)
     size_t value = 0;
     char *env = getenv("CK_MAX_MSG_SIZE");
     if (env)
-        value = (size_t)strtoul(env, NULL, 10); // Cast in case size_t != unsigned long.
+        value = (size_t)strtoul(env, NULL, 10); /* Cast in case size_t != unsigned long. */
     if (value == 0)
         value = ck_max_msg_size;
     if (value == 0)

--- a/src/check_run.c
+++ b/src/check_run.c
@@ -29,6 +29,10 @@
 #include <signal.h>
 #include <setjmp.h>
 
+#if defined(HAVE_FORK) && HAVE_FORK==1
+# include <sys/wait.h>
+#endif
+
 #include "check.h"
 #include "check_error.h"
 #include "check_list.h"

--- a/tests/check_check_master.c
+++ b/tests/check_check_master.c
@@ -43,10 +43,10 @@ char * line_num_failures_file_name = NULL;
 
 enum ck_test_msg_type_t {
 #if ENABLE_REGEX
-  // For tests with different output on different platforms
+  /* For tests with different output on different platforms */
   CK_MSG_REGEXP,
 #endif
-  // Simple text
+  /* Simple text */
   CK_MSG_TEXT
 };
 

--- a/tests/check_check_sub.c
+++ b/tests/check_check_sub.c
@@ -936,7 +936,7 @@ START_TEST(test_ck_assert_float_finite)
   record_test_name(tcase_name());
 
   ck_assert_float_finite(x);
-  // MS VS doesn't allow explicit division by zero
+  /* MS VS doesn't allow explicit division by zero */
   x = 1.0f / (1.0f - t);
   record_failure_line_num(__LINE__);
   ck_assert_float_finite(x);
@@ -1452,7 +1452,7 @@ START_TEST(test_ck_assert_double_finite)
   record_test_name(tcase_name());
 
   ck_assert_double_finite(x);
-  // MS VS doesn't allow explicit division by zero
+  /* MS VS doesn't allow explicit division by zero */
   x = 1.0 / (1.0 - t);
   record_failure_line_num(__LINE__);
   ck_assert_double_finite(x);
@@ -1970,7 +1970,7 @@ START_TEST(test_ck_assert_ldouble_finite)
   record_test_name(tcase_name());
 
   ck_assert_ldouble_finite(x);
-  // MS VS doesn't allow explicit division by zero
+  /* MS VS doesn't allow explicit division by zero */
   x = 1.0l / (1.0l - t);
   record_failure_line_num(__LINE__);
   ck_assert_ldouble_finite(x);

--- a/tests/check_set_max_msg_size.c
+++ b/tests/check_set_max_msg_size.c
@@ -64,8 +64,8 @@ int main (int argc, char *argv[])
      * Run the test suite. This is intended to trigger the "Message is too long" error.
      * Actual success/failure is determined by examining the output.
      */
-    check_set_max_msg_size(32);            // 1st call has no effect since
-    check_set_max_msg_size(atoi(argv[1])); // the 2nd call will override it.
+    check_set_max_msg_size(32);            /* 1st call has no effect since   */
+    check_set_max_msg_size(atoi(argv[1])); /* the 2nd call will override it. */
     sr = srunner_create(make_set_max_msg_size_suite());
     srunner_run_all(sr, CK_NORMAL);
     srunner_free(sr);


### PR DESCRIPTION
    Fix required C standard from C90 to C99
    
    We are using C99 features, such as anonymous variadic macros and
    mixed declarations and code.
    
    Besides, we are using POSIX extensions (fork, etc.), so there is
    (probably?) no point in forcing the use of the old ANSI C89 / ISO C90.
