### PR TITLE
Support CMake package registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,29 +487,43 @@ set(EXPORT_NAME ${PROJECT_NAME})
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${EXPORT_NAME}-config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/${EXPORT_NAME}-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/${EXPORT_NAME}-config.cmake
   INSTALL_DESTINATION ${LIB_INSTALL_DIR}/${EXPORT_NAME}/cmake
 )
 write_basic_package_version_file(
-  ${CMAKE_CURRENT_BINARY_DIR}/${EXPORT_NAME}-config-version.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/${EXPORT_NAME}-config-version.cmake
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY AnyNewerVersion
 )
 
 export(EXPORT check-targets
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/check-targets.cmake"
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${EXPORT_NAME}-targets.cmake"
   NAMESPACE Check::
 )
 
 install(EXPORT check-targets
   NAMESPACE Check::
-  FILE check-targets.cmake
+  FILE "${EXPORT_NAME}-targets.cmake"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${EXPORT_NAME}
 )
 install(
   FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/${EXPORT_NAME}-config.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/${EXPORT_NAME}-config-version.cmake"
+    "${CMAKE_BINARY_DIR}/cmake/${EXPORT_NAME}-config.cmake"
+    "${CMAKE_BINARY_DIR}/cmake/${EXPORT_NAME}-config-version.cmake"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${EXPORT_NAME}
 )
+
+# Store the current build directory in the CMake user package registry.
+# This helps dependent projects use a package from the current
+# project’s build tree, i.e. without installing it.
+
+# In CMake 3.14 and below the export(PACKAGE) command populated
+# the user package registry by default and users needed to set
+# the CMAKE_EXPORT_NO_PACKAGE_REGISTRY to disable it,
+# e.g. in automated build and packaging environments. Since
+# the user package registry is stored outside the build tree,
+# this side effect should not be enabled by default.
+# Therefore CMake 3.15 and above prefer that export(PACKAGE) does nothing
+# unless an explicit CMAKE_EXPORT_PACKAGE_REGISTRY variable is set.
+export(PACKAGE "${PROJECT_NAME}")
 

--- a/cmake/check-config.cmake.in
+++ b/cmake/check-config.cmake.in
@@ -1,3 +1,3 @@
 @PACKAGE_INIT@
-include("${CMAKE_CURRENT_LIST_DIR}/check-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@EXPORT_NAME@-targets.cmake")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,10 +138,12 @@ endif (MSVC)
 # More configuration for exporting
 
 set(LIBRARY_OUTPUT_NAME "check")
+list(APPEND public_headers "${CMAKE_CURRENT_BINARY_DIR}/check.h")
+list(APPEND public_headers "${CMAKE_BINARY_DIR}/check_stdint.h")
 
 set_target_properties(check PROPERTIES
   OUTPUT_NAME ${LIBRARY_OUTPUT_NAME}
-  PUBLIC_HEADER ${CMAKE_CURRENT_BINARY_DIR}/check.h
+  PUBLIC_HEADER "${public_headers}"
 )
 
 if (MSVC)
@@ -154,16 +156,18 @@ set_target_properties(checkShared PROPERTIES
   OUTPUT_NAME ${LIBRARY_OUTPUT_NAME}
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR}
-  PUBLIC_HEADER ${CMAKE_CURRENT_BINARY_DIR}/check.h
+  PUBLIC_HEADER "${public_headers}"
 )
 target_include_directories(check
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 target_include_directories(checkShared
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 


### PR DESCRIPTION
Store the current build directory in the CMake user package registry. This helps dependent projects use a package from the current project’s build tree, i.e. without installing it.

Also fix the missing public header check_stdint.h from CMake build.