### PR TITLE
Remove the forcing of the CMake build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,18 @@ project(check
   DESCRIPTION "Unit Testing Framework for C"
   LANGUAGES C)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
+###############################################################################
+# Set build features
+
+# Set CMAKE_BUILD_TYPE to Debug if source directory is a Git repository
+# or user does not override on the command line
+include(BuildType)
+
 ###############################################################################
 # Configure a project for testing with CTest/CDash
 include(CTest)
-
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 macro(extract_version file setting_name)
   file(STRINGS ${file} VERSION_NUMBER REGEX "^${setting_name}")
@@ -48,10 +55,6 @@ set(PROJECT_VERSION_MAJOR ${CHECK_MAJOR_VERSION})
 set(PROJECT_VERSION_MINOR ${CHECK_MINOR_VERSION})
 set(PROJECT_VERSION_PATCH ${CHECK_MICRO_VERSION})
 set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
-
-###############################################################################
-# Set build features
-set(CMAKE_BUILD_TYPE Debug)
 
 ###############################################################################
 # Provides install directory variables as defined by the GNU Coding Standards.

--- a/cmake/BuildType.cmake
+++ b/cmake/BuildType.cmake
@@ -1,0 +1,15 @@
+# Set a default build type if none was specified
+set(default_build_type "Release")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  set(default_build_type "Debug")
+endif()
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+


### PR DESCRIPTION
* Do not force the build type to be Debug.
* This actually didn't work because the variable was not declated CACHE.
* Append /cmake dir to CMAKE_MODULE_PATH instead of replacing the
  previous content.

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>