### PR TITLE
configure: check for makeinfo instead of tex for documentation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -182,15 +182,15 @@ AC_CHECK_PROGS(LCOV, lcov, false)
 AC_CHECK_PROGS(GENHTML, genhtml, false)
 
 if test "xtrue" = x"$enable_build_docs"; then
-    AC_CHECK_PROGS(TEX, tex, false)
-    if test "$TEX" = "false"; then
-        # Make it [somewhat] clear to maintainers that tex is missing. Not an error
+    AC_CHECK_PROGS(MAKEINFO, makeinfo, false)
+    if test "$MAKEINFO" = "false"; then
+        # Make it [somewhat] clear to maintainers that makeinfo is missing. Not an error
         # though because 'make install' (which users need) does not build the docs
         # anyway.
-        AC_MSG_WARN(tex not installed: cannot rebuild HTML documentation.)
+        AC_MSG_WARN(makeinfo not installed: cannot rebuild HTML documentation.)
     fi
 
-    AM_CONDITIONAL(MAKE_DOCS, [test x"$TEX" != "xfalse"])
+    AM_CONDITIONAL(MAKE_DOCS, [test x"$MAKEINFO" != "xfalse"])
 else
    AM_CONDITIONAL(MAKE_DOCS, [false])
 fi


### PR DESCRIPTION
While upgrading the Alpine Linux check package to 0.13.0 I noticed that
documentation files were no longer installed, even though they were
installed successfully previously.

After investigating this for a while I noticed that this seems to be due
to an incorrect fix for #206. In #206 the issue reporter complains that
the build fails if texinfo is not installed, the fix in #212 checks for
tex instead of makeinfo though. makeinfo is the command used by the
implicit gnu make rule to generate info pages.