### PR TITLE
Rename cmake project from 'check' to 'Check'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,13 +485,12 @@ endif (BUILD_TESTING)
 
 ###############################################################################
 # Export project, prepare a config and config-version files
-set(LIB_INSTALL_DIR lib CACHE FILEPATH "lib INSTALL DIR")
 string(TOLOWER ${PROJECT_NAME} EXPORT_NAME)
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${EXPORT_NAME}-config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/${EXPORT_NAME}-config.cmake
-  INSTALL_DESTINATION ${LIB_INSTALL_DIR}/${EXPORT_NAME}/cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/${EXPORT_NAME}/cmake
 )
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/cmake/${EXPORT_NAME}-config-version.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(POLICY CMP0076)
   # target_sources() leaves relative source file paths unmodified. (OLD)
   cmake_policy(SET CMP0076 OLD)
 endif()
-project(check
+project(Check
   DESCRIPTION "Unit Testing Framework for C"
   LANGUAGES C)
 
@@ -486,7 +486,7 @@ endif (BUILD_TESTING)
 ###############################################################################
 # Export project, prepare a config and config-version files
 set(LIB_INSTALL_DIR lib CACHE FILEPATH "lib INSTALL DIR")
-set(EXPORT_NAME ${PROJECT_NAME})
+string(TOLOWER ${PROJECT_NAME} EXPORT_NAME)
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${EXPORT_NAME}-config.cmake.in
@@ -501,11 +501,11 @@ write_basic_package_version_file(
 
 export(EXPORT check-targets
   FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${EXPORT_NAME}-targets.cmake"
-  NAMESPACE Check::
+  NAMESPACE "${PROJECT_NAME}::"
 )
 
 install(EXPORT check-targets
-  NAMESPACE Check::
+  NAMESPACE "${PROJECT_NAME}::"
   FILE "${EXPORT_NAME}-targets.cmake"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${EXPORT_NAME}
 )

--- a/doc/example/cmake/FindCheck.cmake
+++ b/doc/example/cmake/FindCheck.cmake
@@ -20,12 +20,12 @@
 INCLUDE( FindPkgConfig )
 
 # Take care about check.pc settings
-PKG_SEARCH_MODULE( CHECK check )
+PKG_SEARCH_MODULE( CHECK Check )
 
 # Look for CHECK include dir and libraries
 IF( NOT CHECK_FOUND )
 	IF ( CHECK_INSTALL_DIR )
-		MESSAGE ( STATUS "Using override CHECK_INSTALL_DIR to find check" )
+		MESSAGE ( STATUS "Using override CHECK_INSTALL_DIR to find Check" )
 		SET ( CHECK_INCLUDE_DIR  "${CHECK_INSTALL_DIR}/include" )
 		SET ( CHECK_INCLUDE_DIRS "${CHECK_INCLUDE_DIR}" )
 		FIND_LIBRARY( CHECK_LIBRARY NAMES check PATHS "${CHECK_INSTALL_DIR}/lib" )


### PR DESCRIPTION
    Rename CMake project from 'check' to 'Check'
    
    Check should be written with a capital letter.
    In a CMake script this makes a difference as
    `find_package(Check)` should work, not `find_package(check)`.
    
    This change does not alter how Check is installed.
    Maintaining compatibility with GNU Autotools installation
    is mandatory.
