### PR TITLE
Add ck_skip() and ck_skip_msg(...) macros [WIP] [DISCUSS]

### DIFF
--- a/src/check.h.in
+++ b/src/check.h.in
@@ -489,20 +489,25 @@ static void __testname ## _fn (int _i CK_ATTRIBUTE_UNUSED)
 #define fail ck_abort_msg
 
 /*
- * This is called whenever an assertion fails.
- * Note that it only has the noreturn modifier when
- * using fork. If fork is unavailable, the function
- * calls longjmp() when a test assertion fails. Marking
- * the function as noreturn causes gcc to make assumptions
+ * These are called whenever an assertion fails or a test is skipped.
+ * Note that they only have the noreturn modifier when
+ * using fork. If fork is unavailable, the functions
+ * call longjmp() when a test assertion fails. Marking
+ * the functions as noreturn causes gcc to make assumptions
  * which are not valid, as longjmp() is like a return.
  */
 #if @HAVE_FORK@
 CK_DLL_EXP void CK_EXPORT _ck_assert_failed(const char *file, int line,
                                             const char *expr,
                                             ...) CK_ATTRIBUTE_NORETURN;
+CK_DLL_EXP void CK_EXPORT _ck_skip(const char *file, int line,
+                                   const char *expr,
+                                   ...) CK_ATTRIBUTE_NORETURN;
 #else
 CK_DLL_EXP void CK_EXPORT _ck_assert_failed(const char *file, int line,
                                             const char *expr, ...);
+CK_DLL_EXP void CK_EXPORT _ck_skip(const char *file, int line,
+                                   const char *expr, ...);
 #endif
 
 /**
@@ -552,6 +557,21 @@ CK_DLL_EXP void CK_EXPORT _ck_assert_failed(const char *file, int line,
  * @since 0.9.6
  */
 #define ck_abort_msg(...) _ck_assert_failed(__FILE__, __LINE__, "Failed" , ## __VA_ARGS__, NULL)
+
+/**
+ * Unconditionally mark the test as skipped
+ *
+ * @note Once called, the remaining of the test is aborted
+ */
+#define ck_skip() ck_skip_msg(NULL)
+/**
+ * Unconditionally mark the test as skipped; print a message
+ *
+ * @param ... message to print (in printf format)
+ *
+ * @note Once called, the remaining of the test is aborted
+ */
+#define ck_skip_msg(...) _ck_skip(__FILE__, __LINE__, "Skipped" , ## __VA_ARGS__, NULL)
 
 /* Signed and unsigned integer comparison macros with improved output compared to ck_assert(). */
 /* OP may be any comparison operator. */
@@ -1812,8 +1832,9 @@ enum test_result
     CK_TEST_RESULT_INVALID,     /**< Default value; should not encounter this */
     CK_PASS,                    /**< Test passed */
     CK_FAILURE,                 /**< Test completed but failed */
-    CK_ERROR                    /**< Test failed to complete
+    CK_ERROR,                   /**< Test failed to complete
                                    (unexpected signal or non-zero early exit) */
+    CK_SKIP                     /**< Test marked as skipped */
 };
 
 /**

--- a/src/check_impl.h
+++ b/src/check_impl.h
@@ -72,6 +72,7 @@ typedef struct TestStats
     int n_checked;
     int n_failed;
     int n_errors;
+    int n_skipped;
 } TestStats;
 
 struct TestResult
@@ -85,6 +86,7 @@ struct TestResult
     const char *tcname;         /* Test case that generated the result */
     const char *tname;          /* Test that generated the result */
     char *msg;                  /* Failure message */
+    int wasskipped;             /* Whether the test was skipped */
 };
 
 TestResult *tr_create(void);

--- a/src/check_log.c
+++ b/src/check_log.c
@@ -370,9 +370,9 @@ void tap_lfun(SRunner * sr CK_ATTRIBUTE_UNUSED, FILE * file,
             /* Print the test result to the tap file */
             num_tests_run += 1;
             tr = (TestResult *)obj;
-            fprintf(file, "%s %d - %s:%s:%s: %s\n",
-                    tr->rtype == CK_PASS ? "ok" : "not ok", num_tests_run,
-                    tr->file, tr->tcname, tr->tname, tr->msg);
+            fprintf(file, "%s %d - %s:%s:%s: %s%s\n",
+                    tr->rtype == CK_PASS || tr->rtype == CK_SKIP ? "ok" : "not ok", num_tests_run,
+                    tr->file, tr->tcname, tr->tname, tr->rtype == CK_SKIP ? "# skip " : "", tr->msg);
             fflush(file);
             break;
         default:
@@ -429,6 +429,9 @@ void subunit_lfun(SRunner * sr, FILE * file, enum print_output printmode,
                         break;
                     case CK_ERROR:
                         subunit_test_error(name, msg);
+                        break;
+                    case CK_SKIP:
+                        subunit_test_skip(name, msg);
                         break;
                     case CK_TEST_RESULT_INVALID:
                     default:

--- a/src/check_msg.c
+++ b/src/check_msg.c
@@ -82,11 +82,12 @@ static FILE *get_pipe(void)
     return NULL;
 }
 
-void send_failure_info(const char *msg)
+void send_failure_info(const char *msg, int wasskipped)
 {
     FailMsg fmsg;
 
     fmsg.msg = strdup(msg);
+    fmsg.wasskipped = wasskipped;
     ppack(get_pipe(), CK_MSG_FAIL, (CheckMsg *) & fmsg);
     free(fmsg.msg);
 }
@@ -184,6 +185,7 @@ static TestResult *construct_test_result(RcvMsg * rmsg, int waserror)
             tr->ctx = rmsg->lastctx;
         }
 
+        tr->wasskipped = rmsg->wasskipped;
         tr->msg = rmsg->msg;
         rmsg->msg = NULL;
         tr_set_loc_by_ctx(tr, tr->ctx, rmsg);

--- a/src/check_msg.h
+++ b/src/check_msg.h
@@ -24,7 +24,7 @@
 
 /* Functions implementing messaging during test runs */
 
-void send_failure_info(const char *msg);
+void send_failure_info(const char *msg, int wasskipped);
 void send_loc_info(const char *file, int line);
 void send_ctx_info(enum ck_result_ctx ctx);
 void send_duration_info(int duration);

--- a/src/check_pack.c
+++ b/src/check_pack.c
@@ -328,10 +328,11 @@ static size_t pack_fail(char **buf, FailMsg * fmsg)
     char *ptr;
     size_t len;
 
-    len = 4 + 4 + (fmsg->msg ? strlen(fmsg->msg) : 0);
+    len = 4 + 4 + 4 + (fmsg->msg ? strlen(fmsg->msg) : 0);
     *buf = ptr = (char *)emalloc(len);
 
     pack_type(&ptr, CK_MSG_FAIL);
+    pack_int(&ptr, fmsg->wasskipped);
     pack_str(&ptr, fmsg->msg);
 
     return len;
@@ -339,6 +340,7 @@ static size_t pack_fail(char **buf, FailMsg * fmsg)
 
 static void upack_fail(char **buf, FailMsg * fmsg)
 {
+    fmsg->wasskipped = upack_int(buf);
     fmsg->msg = upack_str(buf);
 }
 
@@ -431,6 +433,7 @@ static size_t get_result(char *buf, RcvMsg * rmsg)
         {
             rmsg->msg = strdup(fmsg->msg);
             rmsg->failctx = rmsg->lastctx;
+            rmsg->wasskipped = fmsg->wasskipped;
         }
         else
         {
@@ -471,6 +474,7 @@ static RcvMsg *rcvmsg_create(void)
     rmsg->failctx = CK_CTX_INVALID;
     rmsg->msg = NULL;
     rmsg->duration = -1;
+    rmsg->wasskipped = 0;
     reset_rcv_test(rmsg);
     reset_rcv_fixture(rmsg);
     return rmsg;

--- a/src/check_pack.h
+++ b/src/check_pack.h
@@ -45,6 +45,7 @@ typedef struct LocMsg
 typedef struct FailMsg
 {
     char *msg;
+    int wasskipped;
 } FailMsg;
 
 typedef struct DurationMsg
@@ -70,6 +71,7 @@ typedef struct RcvMsg
     int test_line;
     char *msg;
     int duration;
+    int wasskipped;
 } RcvMsg;
 
 void rcvmsg_free(RcvMsg * rmsg);

--- a/src/check_print.c
+++ b/src/check_print.c
@@ -184,6 +184,9 @@ void tr_xmlprint(FILE * file, TestResult * tr,
         case CK_ERROR:
             snprintf(result, sizeof(result), "%s", "error");
             break;
+        case CK_SKIP:
+            snprintf(result, sizeof(result), "%s", "skipped");
+            break;
         case CK_TEST_RESULT_INVALID:
         default:
             abort();

--- a/src/check_run.c
+++ b/src/check_run.c
@@ -284,6 +284,8 @@ static void srunner_add_failure(SRunner * sr, TestResult * tr)
         sr->stats->n_failed++;
     else if(tr->rtype == CK_ERROR)
         sr->stats->n_errors++;
+    if(tr->rtype == CK_SKIP)
+        sr->stats->n_skipped++;
 
 }
 
@@ -460,7 +462,7 @@ static void set_nofork_info(TestResult * tr)
     }
     else
     {
-        tr->rtype = CK_FAILURE;
+        tr->rtype = tr->wasskipped ? CK_SKIP : CK_FAILURE;
     }
 }
 
@@ -639,7 +641,7 @@ static void set_fork_info(TestResult * tr, int status, int signal_expected,
             }
             else
             {
-                tr->rtype = CK_FAILURE;
+                tr->rtype = tr->wasskipped ? CK_SKIP : CK_FAILURE;
             }
         }
     }
@@ -654,11 +656,11 @@ static void set_fork_info(TestResult * tr, int status, int signal_expected,
             tr->msg = exit_msg(exit_status);
             if(exit_status == allowed_exit_value)
             {
-                tr->rtype = CK_FAILURE; /* normal exit status */
+                tr->rtype = tr->wasskipped ? CK_SKIP : CK_FAILURE; /* normal exit status */
             }
             else
             {
-                tr->rtype = CK_FAILURE; /* early exit */
+                tr->rtype = tr->wasskipped ? CK_SKIP : CK_FAILURE; /* early exit */
             }
         }
     }

--- a/src/check_str.c
+++ b/src/check_str.c
@@ -67,9 +67,15 @@ char *sr_stat_str(SRunner * sr)
 
     ts = sr->stats;
 
-    str = ck_strdup_printf("%d%%: Checks: %d, Failures: %d, Errors: %d",
-                           percent_passed(ts), ts->n_checked, ts->n_failed,
-                           ts->n_errors);
+    if (ts->n_skipped <= 0) {
+        str = ck_strdup_printf("%d%%: Checks: %d, Failures: %d, Errors: %d",
+                               percent_passed(ts), ts->n_checked, ts->n_failed,
+                               ts->n_errors);
+    } else {
+        str = ck_strdup_printf("%d%%: Checks: %d, Failures: %d, Errors: %d, Skipped: %d",
+                               percent_passed(ts), ts->n_checked, ts->n_failed,
+                               ts->n_errors, ts->n_skipped);
+    }
 
     return str;
 }
@@ -114,6 +120,8 @@ static const char *tr_type_str(TestResult * tr)
             return "F";
         if(tr->rtype == CK_ERROR)
             return "E";
+        if(tr->rtype == CK_SKIP)
+            return "K";
         return NULL;
     }
     return "S";
@@ -125,6 +133,6 @@ static int percent_passed(TestStats * t)
         return 100;
     if(t->n_checked == 0)
         return 0;
-    return (int)((float)(t->n_checked - (t->n_failed + t->n_errors)) /
-                 (float)t->n_checked * 100);
+    return (int)((float)(t->n_checked - t->n_skipped - (t->n_failed + t->n_errors)) /
+                 (float)(t->n_checked - t->n_skipped) * 100);
 }

--- a/tests/check_check_master.c
+++ b/tests/check_check_master.c
@@ -269,6 +269,8 @@ static master_test_t master_tests[] = {
   { "Simple Tests", "test_ck_assert_mem_zerolen", CK_PASS, CK_MSG_TEXT,    "Passed" },
   { "Simple Tests", "test_ck_assert_mem_eq_exact", CK_FAILURE, CK_MSG_TEXT, "Assertion 't == s' failed: t == \"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001\", s == \"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002\"" },
   { "Simple Tests", "test_ck_assert_mem_eq_longer", CK_FAILURE, CK_MSG_TEXT, "Assertion 't == s' failed: t == \"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000..\", s == \"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000..\"" },
+  { "Simple Tests", "test_ck_skip", CK_SKIP, CK_MSG_TEXT, "Skipped" },
+  { "Simple Tests", "test_ck_skip_msg", CK_SKIP, CK_MSG_TEXT, "this is why we skipped: 0" },
   
 #if defined(HAVE_FORK) && HAVE_FORK==1
   { "Signal Tests", "test_segv", CK_ERROR, CK_MSG_TEXT,   signal_11_str },
@@ -419,7 +421,7 @@ START_TEST(test_check_nfailures)
   int number_failed = 0;
   
   for (i = 0; i < nr_of_master_tests; i++) {
-    if (master_tests[i].failure_type != CK_PASS) {
+    if (master_tests[i].failure_type != CK_PASS && master_tests[i].failure_type != CK_SKIP) {
       number_failed++;
     }
   }
@@ -487,7 +489,7 @@ START_TEST(test_check_failure_msgs)
   for (i = 0; i < sub_ntests; i++) {
     master_test_t *master_test = &master_tests[i];
 
-    if (master_test->failure_type == CK_PASS) {
+    if (master_test->failure_type == CK_PASS || master_tests[i].failure_type == CK_SKIP) {
       passed++;
       continue;
     }
@@ -573,6 +575,10 @@ START_TEST(test_check_failure_lnos)
     if (master_tests[i].failure_type == CK_PASS) {
       passed++;
       continue;
+    } else if (master_tests[i].failure_type == CK_SKIP) {
+      (void) get_next_failure_line_num(line_num_failures);
+      passed++;
+      continue;
     }
 
     number_failed = i - passed;
@@ -608,7 +614,7 @@ START_TEST(test_check_failure_ftypes)
   TestResult *tr;
   
   for (i = 0; i < sub_ntests; i++) {
-    if (master_tests[i].failure_type == CK_PASS) {
+    if (master_tests[i].failure_type == CK_PASS || master_tests[i].failure_type == CK_SKIP) {
       passed++;
       continue;
     }

--- a/tests/check_check_msg.c
+++ b/tests/check_check_msg.c
@@ -39,7 +39,7 @@ START_TEST(test_send)
   send_ctx_info(CK_CTX_TEST);
   send_loc_info("abc124.c", 22);
   send_loc_info("abc125.c", 25);
-  send_failure_info("Oops");
+  send_failure_info("Oops", 0);
   tr = receive_test_result(0);
   teardown_messaging();
 

--- a/tests/check_check_pack.c
+++ b/tests/check_check_pack.c
@@ -42,9 +42,11 @@ START_TEST(test_pack_fmsg)
   fmsg = (FailMsg *)emalloc (sizeof (FailMsg));
 
   fmsg->msg = (char *) "Hello, world!";
+  fmsg->wasskipped = 0;
   pack (CK_MSG_FAIL, &buf, (CheckMsg *) fmsg);
 
   fmsg->msg = NULL;
+  fmsg->wasskipped = 0;
   upack (buf, (CheckMsg *) fmsg, &type);
 
   ck_assert_msg (type == CK_MSG_FAIL,
@@ -191,8 +193,10 @@ START_TEST(test_pack_fail_limit)
   enum ck_msg_type type;
 
   fmsg.msg = (char *) "";
+  fmsg.wasskipped = 0;
   pack (CK_MSG_FAIL, &buf, (CheckMsg *) &fmsg);
   fmsg.msg = NULL;
+  fmsg.wasskipped = 0;
   upack (buf, (CheckMsg *) &fmsg, &type);
   free (buf);
   ck_assert_msg (fmsg.msg != NULL,
@@ -202,6 +206,7 @@ START_TEST(test_pack_fail_limit)
 
   free (fmsg.msg);
   fmsg.msg = NULL;
+  fmsg.wasskipped = 0;
 
   pack (CK_MSG_FAIL, &buf, (CheckMsg *) &fmsg);
   pack (CK_MSG_FAIL, &buf, (CheckMsg *) fmsgp);
@@ -247,6 +252,7 @@ START_TEST(test_ppack)
   lmsg.file = (char *) "abc123.c";
   lmsg.line = 10;
   fmsg.msg = (char *) "oops";
+  fmsg.wasskipped = 0;
   result_file = open_tmp_file(&result_file_name);
   free(result_file_name);
   ppack (result_file, CK_MSG_CTX, (CheckMsg *) &cmsg);
@@ -287,6 +293,7 @@ START_TEST(test_ppack_noctx)
   lmsg.file = (char *) "abc123.c";
   lmsg.line = 10;
   fmsg.msg = (char *) "oops";
+  fmsg.wasskipped = 0;
   result_file = open_tmp_file(&result_file_name);
   free(result_file_name);
   ppack (result_file, CK_MSG_LOC, (CheckMsg *) &lmsg);
@@ -408,6 +415,7 @@ START_TEST(test_ppack_big)
   lmsg.file[BIG_MSG_LEN - 1] = '\0';
   lmsg.line = 10;
   fmsg.msg = (char *)emalloc (BIG_MSG_LEN);
+  fmsg.wasskipped = 0;
   memset (fmsg.msg, 'a', BIG_MSG_LEN - 1);
   fmsg.msg[BIG_MSG_LEN - 1] = '\0';
   result_file = open_tmp_file(&result_file_name);

--- a/tests/check_check_sub.c
+++ b/tests/check_check_sub.c
@@ -2502,6 +2502,26 @@ START_TEST(test_ck_assert_mem_eq_longer)
 }
 END_TEST
 
+START_TEST(test_ck_skip)
+{
+  record_test_name(tcase_name());
+
+  record_failure_line_num(__LINE__);
+  ck_skip();
+  ck_abort_msg("should not reach");
+}
+END_TEST
+
+START_TEST(test_ck_skip_msg)
+{
+  record_test_name(tcase_name());
+
+  record_failure_line_num(__LINE__);
+  ck_skip_msg("this is why we skipped: %d", 0);
+  ck_abort_msg("should not reach");
+}
+END_TEST
+
 #if defined(HAVE_FORK) && HAVE_FORK == 1
 START_TEST(test_segv_pass)
 {
@@ -3220,6 +3240,8 @@ Suite *make_sub_suite(void)
   tcase_add_test (tc_simple, test_ck_assert_mem_zerolen);
   tcase_add_test (tc_simple, test_ck_assert_mem_eq_exact);
   tcase_add_test (tc_simple, test_ck_assert_mem_eq_longer);
+  tcase_add_test (tc_simple, test_ck_skip);
+  tcase_add_test (tc_simple, test_ck_skip_msg);
 
 #if defined(HAVE_FORK) && HAVE_FORK==1
   tcase_add_test (tc_signal, test_segv);

--- a/tests/ex_output.c
+++ b/tests/ex_output.c
@@ -79,6 +79,12 @@ START_TEST(test_xml_esc_fail_msg)
 }
 END_TEST
 
+START_TEST(test_skip)
+{
+    ck_skip_msg("Skip Message");
+}
+END_TEST
+
 static Suite *make_log1_suite(void)
 {
     Suite *s;
@@ -89,6 +95,7 @@ static Suite *make_log1_suite(void)
     suite_add_tcase(s, tc);
     tcase_add_test(tc, test_pass);
     tcase_add_test(tc, test_fail);
+    tcase_add_test(tc, test_skip);
 #if defined(HAVE_FORK) && HAVE_FORK==1
     tcase_add_test(tc, test_exit);
 #endif /* HAVE_FORK */

--- a/tests/test_output_strings
+++ b/tests/test_output_strings
@@ -21,23 +21,25 @@ suite_output=`printf "Running suite(s): S1
 exp_silent=""
 
 if [ $HAVE_FORK -eq 1 ]; then
-exp_minimal_result="37%: Checks: 8, Failures: 4, Errors: 1"
+exp_minimal_result="37%: Checks: 9, Failures: 4, Errors: 1, Skipped: 1"
 else
-exp_minimal_result="42%: Checks: 7, Failures: 4, Errors: 0"
+exp_minimal_result="42%: Checks: 8, Failures: 4, Errors: 0, Skipped: 1"
 fi
 exp_minimal="$suite_output
 $exp_minimal_result"
 
 if [ $HAVE_FORK -eq 1 ]; then
-exp_normal_result=`printf "37%%: Checks: 8, Failures: 4, Errors: 1
+exp_normal_result=`printf "37%%: Checks: 9, Failures: 4, Errors: 1, Skipped: 1
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:84:K:Core:test_skip:0: Skip Message
 ${SRCDIR}ex_output.c:46:E:Core:test_exit:0: (after this point) Early exit with return value 1
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
 ${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
 else
-exp_normal_result=`printf "42%%: Checks: 7, Failures: 4, Errors: 0
+exp_normal_result=`printf "42%%: Checks: 8, Failures: 4, Errors: 0, Skipped: 1
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:84:K:Core:test_skip:0: Skip Message
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
 ${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
@@ -47,9 +49,10 @@ $exp_normal_result"
 
 
 if [ $HAVE_FORK -eq 1 ]; then
-exp_verbose_result=`printf "37%%: Checks: 8, Failures: 4, Errors: 1
+exp_verbose_result=`printf "37%%: Checks: 9, Failures: 4, Errors: 1, Skipped: 1
 ${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:84:K:Core:test_skip:0: Skip Message
 ${SRCDIR}ex_output.c:46:E:Core:test_exit:0: (after this point) Early exit with return value 1
 ${SRCDIR}ex_output.c:66:P:Core:test_pass2:0: Passed
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
@@ -57,9 +60,10 @@ ${SRCDIR}ex_output.c:72:P:Core:test_loop:1: Passed
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
 ${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message"`
 else
-exp_verbose_result=`printf "42%%: Checks: 7, Failures: 4, Errors: 0
+exp_verbose_result=`printf "42%%: Checks: 8, Failures: 4, Errors: 0, Skipped: 1
 ${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:84:K:Core:test_skip:0: Skip Message
 ${SRCDIR}ex_output.c:66:P:Core:test_pass2:0: Passed
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
 ${SRCDIR}ex_output.c:72:P:Core:test_loop:1: Passed
@@ -75,6 +79,10 @@ success: Core:test_pass
 test: Core:test_fail
 failure: Core:test_fail [
 ${SRCDIR}ex_output.c:37: Failure
+]
+test: Core:test_skip
+skip: Core:test_skip [
+${SRCDIR}ex_output.c:84: Skip Message
 ]
 test: Core:test_exit
 error: Core:test_exit [
@@ -103,6 +111,10 @@ test: Core:test_fail
 failure: Core:test_fail [
 ${SRCDIR}ex_output.c:37: Failure
 ]
+test: Core:test_skip
+skip: Core:test_skip [
+${SRCDIR}ex_output.c:84: Skip Message
+]
 test: Core:test_pass2
 success: Core:test_pass2
 test: Core:test_loop
@@ -128,6 +140,7 @@ if [ $HAVE_FORK -eq 1 ]; then
 expected_log_log=`printf "Running suite S1
 ${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:84:K:Core:test_skip:0: Skip Message
 ${SRCDIR}ex_output.c:46:E:Core:test_exit:0: (after this point) Early exit with return value 1
 Running suite S2
 ${SRCDIR}ex_output.c:66:P:Core:test_pass2:0: Passed
@@ -137,11 +150,12 @@ ${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
 Running suite XML escape \" ' < > & $tab_nl_X_bs tests
 ${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message
 Results for all suites run:
-37%%: Checks: 8, Failures: 4, Errors: 1"`
+37%%: Checks: 9, Failures: 4, Errors: 1, Skipped: 1"`
 else
 expected_log_log=`printf "Running suite S1
 ${SRCDIR}ex_output.c:31:P:Core:test_pass:0: Passed
 ${SRCDIR}ex_output.c:37:F:Core:test_fail:0: Failure
+${SRCDIR}ex_output.c:84:K:Core:test_skip:0: Skip Message
 Running suite S2
 ${SRCDIR}ex_output.c:66:P:Core:test_pass2:0: Passed
 ${SRCDIR}ex_output.c:72:F:Core:test_loop:0: Iteration 0 failed
@@ -150,7 +164,7 @@ ${SRCDIR}ex_output.c:72:F:Core:test_loop:2: Iteration 2 failed
 Running suite XML escape \" ' < > & $tab_nl_X_bs tests
 ${SRCDIR}ex_output.c:78:F:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg:0: fail \" ' < > & $tab_nl_X_bs message
 Results for all suites run:
-42%%: Checks: 7, Failures: 4, Errors: 0"`
+42%%: Checks: 8, Failures: 4, Errors: 0, Skipped: 1"`
 fi
 
 ##################
@@ -175,6 +189,13 @@ expected_xml="<?xml version=\"1.0\"?>
       <iteration>0</iteration>
       <description>Core</description>
       <message>Failure</message>
+    </test>
+    <test result=\"skipped\">
+      <fn>ex_output.c:84</fn>
+      <id>test_skip</id>
+      <iteration>0</iteration>
+      <description>Core</description>
+      <message>Skip Message</message>
     </test>
     <test result=\"error\">
       <fn>ex_output.c:46</fn>
@@ -226,7 +247,7 @@ expected_xml="<?xml version=\"1.0\"?>
     </test>
   </suite>
 </testsuites>"
-expected_duration_count=9
+expected_duration_count=10
 else
 expected_xml="<?xml version=\"1.0\"?>
 <?xml-stylesheet type=\"text/xsl\" href=\"http://check.sourceforge.net/xml/check_unittest.xslt\"?>
@@ -246,6 +267,13 @@ expected_xml="<?xml version=\"1.0\"?>
       <iteration>0</iteration>
       <description>Core</description>
       <message>Failure</message>
+    </test>
+    <test result=\"skipped\">
+      <fn>ex_output.c:84</fn>
+      <id>test_skip</id>
+      <iteration>0</iteration>
+      <description>Core</description>
+      <message>Skip Message</message>
     </test>
   </suite>
   <suite>
@@ -290,7 +318,7 @@ expected_xml="<?xml version=\"1.0\"?>
     </test>
   </suite>
 </testsuites>"
-expected_duration_count=8
+expected_duration_count=9
 fi
 
 ##################
@@ -299,32 +327,35 @@ fi
 if [ $HAVE_FORK -eq 1 ]; then
 expected_normal_tap=`printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
 not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
-not ok 3 - ${SRCDIR}ex_output.c:Core:test_exit: Early exit with return value 1
-ok 4 - ${SRCDIR}ex_output.c:Core:test_pass2: Passed
-not ok 5 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 0 failed
-ok 6 - ${SRCDIR}ex_output.c:Core:test_loop: Passed
-not ok 7 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 2 failed
-not ok 8 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message
-1..8"`
-expected_aborted_tap=`printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
-not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
-not ok 3 - ${SRCDIR}ex_output.c:Core:test_exit: Early exit with return value 1
-not ok 4 - ${SRCDIR}ex_output.c:Core:test_abort: Early exit with return value 1
+ok 3 - ${SRCDIR}ex_output.c:Core:test_skip: # skip Skip Message
+not ok 4 - ${SRCDIR}ex_output.c:Core:test_exit: Early exit with return value 1
 ok 5 - ${SRCDIR}ex_output.c:Core:test_pass2: Passed
 not ok 6 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 0 failed
 ok 7 - ${SRCDIR}ex_output.c:Core:test_loop: Passed
 not ok 8 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 2 failed
 not ok 9 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message
 1..9"`
+expected_aborted_tap=`printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
+not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
+ok 3 - ${SRCDIR}ex_output.c:Core:test_skip: # skip Skip Message
+not ok 4 - ${SRCDIR}ex_output.c:Core:test_exit: Early exit with return value 1
+not ok 5 - ${SRCDIR}ex_output.c:Core:test_abort: Early exit with return value 1
+ok 6 - ${SRCDIR}ex_output.c:Core:test_pass2: Passed
+not ok 7 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 0 failed
+ok 8 - ${SRCDIR}ex_output.c:Core:test_loop: Passed
+not ok 9 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 2 failed
+not ok 10 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message
+1..10"`
 else
 expected_normal_tap=`printf "ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
 not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
-ok 3 - ${SRCDIR}ex_output.c:Core:test_pass2: Passed
-not ok 4 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 0 failed
-ok 5 - ${SRCDIR}ex_output.c:Core:test_loop: Passed
-not ok 6 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 2 failed
-not ok 7 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message
-1..7"`
+ok 3 - ${SRCDIR}ex_output.c:Core:test_skip: # skip Skip Message
+ok 4 - ${SRCDIR}ex_output.c:Core:test_pass2: Passed
+not ok 5 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 0 failed
+ok 6 - ${SRCDIR}ex_output.c:Core:test_loop: Passed
+not ok 7 - ${SRCDIR}ex_output.c:Core:test_loop: Iteration 2 failed
+not ok 8 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml_esc_fail_msg: fail \" ' < > & $tab_nl_X_bs message
+1..8"`
 # When fork() is unavailable, one of the tests
 # will invoke exit() which will terminate the
 # unit testing program. In that case, the tap
@@ -332,5 +363,6 @@ not ok 7 - ${SRCDIR}ex_output.c:description \" ' < > & $tab_nl_X_bs end:test_xml
 # test plan will be missing, signaling that
 # something bad happened.
 expected_aborted_tap="ok 1 - ${SRCDIR}ex_output.c:Core:test_pass: Passed
-not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure"
+not ok 2 - ${SRCDIR}ex_output.c:Core:test_fail: Failure
+ok 3 - ${SRCDIR}ex_output.c:Core:test_skip: # skip Skip Message"
 fi


### PR DESCRIPTION
* `ck_skip()` aborts the test and marks it as skipped
* `ck_skip_msg(...)` does the same with a custom printf message
* `_ck_skip()` is exposed as a symbol

These are all analogues of `ck_abort()`, `ck_abort_msg()`, and `_ck_assert_failed()`

Since they basically work like `ck_abort()`, I decided to use a flag `wasskipped` in `FailMsg` instead of adding a new message type.

As it is, I'm not including skipped tests in the success percentage, but they are included in total tests run. I considered adding `srunner_ntests_skipped()` and `srunner_skipped()` but decided to hold off since they are included in `srunner_results()`

In `tr_type_str`, I assigned skip to `K` because the default return value was `S` already. I'm not sure if there's a more appropriate value here.

I'm personally using check with the autotools tap driver, and it seems to be working alright so far.

Let me know if you have any thoughts and, of course, feel free to request changes.

Closes #178 