### PR TITLE
Fix format specifiers that do not match the argument types

### DIFF
--- a/src/check.h.in
+++ b/src/check.h.in
@@ -1724,7 +1724,7 @@ do { \
 #define _ck_assert_ptr(X, OP, Y) do { \
   const void* _ck_x = (X); \
   const void* _ck_y = (Y); \
-  ck_assert_msg(_ck_x OP _ck_y, "Assertion '%s' failed: %s == %#x, %s == %#x", #X" "#OP" "#Y, #X, _ck_x, #Y, _ck_y); \
+  ck_assert_msg(_ck_x OP _ck_y, "Assertion '%s' failed: %s == %#lx, %s == %#lx", #X" "#OP" "#Y, #X, (unsigned long)_ck_x, #Y, (unsigned long)_ck_y); \
 } while (0)
 
 /* Pointer against NULL comparison macros with improved output
@@ -1733,9 +1733,9 @@ do { \
 #define _ck_assert_ptr_null(X, OP) do { \
   const void* _ck_x = (X); \
   ck_assert_msg(_ck_x OP NULL, \
-  "Assertion '%s' failed: %s == %#x", \
+  "Assertion '%s' failed: %s == %#lx", \
   #X" "#OP" NULL", \
-  #X, _ck_x); \
+  #X, (unsigned long)_ck_x); \
 } while (0)
 
 /**

--- a/src/check_error.c
+++ b/src/check_error.c
@@ -61,7 +61,7 @@ void *emalloc(size_t n)
 
     p = malloc(n);
     if(p == NULL)
-        eprintf("malloc of %u bytes failed:", __FILE__, __LINE__ - 2, n);
+        eprintf("malloc of %zu bytes failed:", __FILE__, __LINE__ - 2, n);
     return p;
 }
 
@@ -71,6 +71,6 @@ void *erealloc(void *ptr, size_t n)
 
     p = realloc(ptr, n);
     if(p == NULL)
-        eprintf("realloc of %u bytes failed:", __FILE__, __LINE__ - 2, n);
+        eprintf("realloc of %zu bytes failed:", __FILE__, __LINE__ - 2, n);
     return p;
 }

--- a/src/check_pack.c
+++ b/src/check_pack.c
@@ -136,7 +136,7 @@ int pack(enum ck_msg_type type, char **buf, CheckMsg * msg)
 
     len = pftab[type] (buf, msg);
     if(len > (size_t) INT_MAX)
-        eprintf("Value of len (%d) too big, max allowed %u\n",
+        eprintf("Value of len (%zu) too big, max allowed %u\n",
                 __FILE__, __LINE__ - 3, len, INT_MAX);
     return (int) len;
 }
@@ -159,10 +159,10 @@ int upack(char *buf, CheckMsg * msg, enum ck_msg_type *type)
 
     diff = buf - obuf;
     if(diff > (ptrdiff_t) INT_MAX)
-        eprintf("Value of diff (%t) too big, max allowed %u\n",
+        eprintf("Value of diff (%td) too big, max allowed %d\n",
                 __FILE__, __LINE__ - 3, diff, INT_MAX);
     if(diff > (ptrdiff_t) INT_MAX || diff < (ptrdiff_t) INT_MIN)
-        eprintf("Value of diff (%t) too small, min allowed %u\n",
+        eprintf("Value of diff (%td) too small, min allowed %d\n",
                 __FILE__, __LINE__ - 6, diff, INT_MIN);
     return (int) diff;
 }

--- a/tests/check_check_master.c
+++ b/tests/check_check_master.c
@@ -589,7 +589,7 @@ START_TEST(test_check_failure_lnos)
     }
 
     if (line_no > 0 && tr_lno(tr) != line_no) {
-      ck_abort_msg("For test %d (failure %d): Expected lno %d, got %d for suite %s, msg %s",
+      ck_abort_msg("For test %d (failure %d): Expected lno %ld, got %d for suite %s, msg %s",
                i, number_failed, line_no, tr_lno(tr), tr_tcname(tr), tr_msg(tr));
     }    
   }
@@ -597,7 +597,7 @@ START_TEST(test_check_failure_lnos)
   /* At this point, there should be no remaining failures */
   line_no = get_next_failure_line_num(line_num_failures);
   ck_assert_msg(line_no == -1,
-    "No more failure line numbers expected, but found %d", line_no);
+    "No more failure line numbers expected, but found %ld", line_no);
 }
 END_TEST
 


### PR DESCRIPTION
In check.h.in, %x is not safe to use with pointers, since it specifies an int-sized value but a pointer is passed in.  On some platforms, `int` is 32 bits and `void *` is 64 bits.

In check_pack.c, note that `t` is a length modifier, not a conversion specifier.  It must be followed by either `d` or `u`; `d` seems appropriate in this case.

The other changes are fairly obvious mismatches between the argument type and conversion specifier.