### PR TITLE
Make CK_ATTRIBUTE_FORMAT refer to the right arguments.

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -362,17 +362,13 @@ void _mark_point(const char *file, int line)
     send_loc_info(file, line);
 }
 
-void _ck_assert_failed(const char *file, int line, const char *expr, ...)
+void _ck_assert_failed(const char *file, int line, const char *expr,
+                       const char *msg, ...)
 {
-    const char *msg;
-    va_list ap;
     char buf[BUFSIZ];
     const char *to_send;
 
     send_loc_info(file, line);
-
-    va_start(ap, expr);
-    msg = (const char *)va_arg(ap, char *);
 
     /*
      * If a message was passed, format it with vsnprintf.
@@ -380,7 +376,10 @@ void _ck_assert_failed(const char *file, int line, const char *expr, ...)
      */
     if(msg != NULL)
     {
+        va_list ap;
+        va_start(ap, msg);
         vsnprintf(buf, BUFSIZ, msg, ap);
+        va_end(ap);
         to_send = buf;
     }
     else
@@ -388,7 +387,6 @@ void _ck_assert_failed(const char *file, int line, const char *expr, ...)
         to_send = expr;
     }
 
-    va_end(ap);
     send_failure_info(to_send);
     if(cur_fork_status() == CK_FORK)
     {

--- a/src/check.h.in
+++ b/src/check.h.in
@@ -480,7 +480,7 @@ static void __testname ## _fn (int _i CK_ATTRIBUTE_UNUSED)
  */
 #define fail_if(expr, ...)\
   (expr) ? \
-     _ck_assert_failed(__FILE__, __LINE__, "Failure '"#expr"' occurred" , ## __VA_ARGS__, NULL) \
+     _ck_assert_failed(__FILE__, __LINE__, "Failure '"#expr"' occurred" , ## __VA_ARGS__) \
      : _mark_point(__FILE__, __LINE__)
 
 /*
@@ -500,11 +500,12 @@ static void __testname ## _fn (int _i CK_ATTRIBUTE_UNUSED)
  */
 #if @HAVE_FORK@
 CK_DLL_EXP void CK_EXPORT _ck_assert_failed(const char *file, int line,
-                                            const char *expr,
-                                            ...) CK_ATTRIBUTE_NORETURN CK_ATTRIBUTE_FORMAT(gnu_printf, 3, 4);
+                                            const char *expr, const char *msg,
+                                            ...) CK_ATTRIBUTE_NORETURN CK_ATTRIBUTE_FORMAT(gnu_printf, 4, 5);
 #else
 CK_DLL_EXP void CK_EXPORT _ck_assert_failed(const char *file, int line,
-                                            const char *expr, ...) CK_ATTRIBUTE_FORMAT(gnu_printf, 3, 4);
+                                            const char *expr, const char *msg,
+                                            ...) CK_ATTRIBUTE_FORMAT(gnu_printf, 4, 5);
 #endif
 
 /**
@@ -534,7 +535,7 @@ CK_DLL_EXP void CK_EXPORT _ck_assert_failed(const char *file, int line,
 #define ck_assert_msg(expr, ...) \
   (expr) ? \
      _mark_point(__FILE__, __LINE__) : \
-     _ck_assert_failed(__FILE__, __LINE__, "Assertion '"#expr"' failed" , ## __VA_ARGS__, NULL)
+     _ck_assert_failed(__FILE__, __LINE__, "Assertion '"#expr"' failed" , ## __VA_ARGS__)
 
 /**
  * Unconditionally fail the test
@@ -553,7 +554,7 @@ CK_DLL_EXP void CK_EXPORT _ck_assert_failed(const char *file, int line,
  *
  * @since 0.9.6
  */
-#define ck_abort_msg(...) _ck_assert_failed(__FILE__, __LINE__, "Failed" , ## __VA_ARGS__, NULL)
+#define ck_abort_msg(...) _ck_assert_failed(__FILE__, __LINE__, "Failed" , ## __VA_ARGS__)
 
 /* Signed and unsigned integer comparison macros with improved output compared to ck_assert(). */
 /* OP may be any comparison operator. */


### PR DESCRIPTION
With the release of version 0.15.0 and the addition of CK_ATTRIBUTE_FORMAT, gcc now complains that every use of a macro with an assert message passes too many arguments for the format.  Part of the problem is some unnecessary passing of trailing NULL arguments.  The main problem, though, is that the CK_ATTRIBUTE_FORMAT directive on `_ck_assert_failed` refers to the wrong arguments.  Argument 3 is `expr`, which is a constant string containing zero format directives.  The argument you want is argument 4, but it cannot be referred to since it is implicit in the triple dots.  The fix is to make it an explicit argument, as in this commit.
