### PR TITLE
Improve the info directory entry

### DIFF
--- a/doc/check.texi
+++ b/doc/check.texi
@@ -28,7 +28,7 @@ entitled ``@acronym{GNU} Free Documentation License.''
 
 @dircategory Software development
 @direntry
-* Check: (check)Introduction.
+* Check: (check).               A unit testing framework for C.
 @end direntry
 
 @titlepage


### PR DESCRIPTION
The main info directory on many Linux distributions contains one line per package, with the identify of the package on the left, and a 1-line summary of its purpose starting at (zero-based) column 32.  This change makes the info entry fit in better on such distributions.