### PR TITLE
Replace gnu_printf with printf in format __attribute__

### DIFF
--- a/src/check.h.in
+++ b/src/check.h.in
@@ -501,11 +501,11 @@ static void __testname ## _fn (int _i CK_ATTRIBUTE_UNUSED)
 #if @HAVE_FORK@
 CK_DLL_EXP void CK_EXPORT _ck_assert_failed(const char *file, int line,
                                             const char *expr, const char *msg,
-                                            ...) CK_ATTRIBUTE_NORETURN CK_ATTRIBUTE_FORMAT(gnu_printf, 4, 5);
+                                            ...) CK_ATTRIBUTE_NORETURN CK_ATTRIBUTE_FORMAT(printf, 4, 5);
 #else
 CK_DLL_EXP void CK_EXPORT _ck_assert_failed(const char *file, int line,
                                             const char *expr, const char *msg,
-                                            ...) CK_ATTRIBUTE_FORMAT(gnu_printf, 4, 5);
+                                            ...) CK_ATTRIBUTE_FORMAT(printf, 4, 5);
 #endif
 
 /**

--- a/src/check_error.h
+++ b/src/check_error.h
@@ -31,7 +31,7 @@ extern jmp_buf error_jmp_buffer;
 /* Print error message and die
    If fmt ends in colon, include system error information */
 void eprintf(const char *fmt, const char *file, int line,
-             ...) CK_ATTRIBUTE_NORETURN CK_ATTRIBUTE_FORMAT(gnu_printf, 1, 4);
+             ...) CK_ATTRIBUTE_NORETURN CK_ATTRIBUTE_FORMAT(printf, 1, 4);
 /* malloc or die */
 void *emalloc(size_t n);
 void *erealloc(void *, size_t n);

--- a/src/check_str.h
+++ b/src/check_str.h
@@ -39,6 +39,6 @@ char *tr_short_str(TestResult * tr);
 */
 char *sr_stat_str(SRunner * sr);
 
-char *ck_strdup_printf(const char *fmt, ...) CK_ATTRIBUTE_FORMAT(gnu_printf, 1, 2);
+char *ck_strdup_printf(const char *fmt, ...) CK_ATTRIBUTE_FORMAT(printf, 1, 2);
 
 #endif /* CHECK_STR_H */


### PR DESCRIPTION
The gnu_printf format attribute was being picked up by clang as
well as gcc. Only gcc defines gnu_printf. Switching to only
'printf' to support clang as well.