### PR TITLE
Resolve warning in ptr macros with pointer to integer cast

### DIFF
--- a/src/check.h.in
+++ b/src/check.h.in
@@ -1725,7 +1725,7 @@ do { \
 #define _ck_assert_ptr(X, OP, Y) do { \
   const void* _ck_x = (X); \
   const void* _ck_y = (Y); \
-  ck_assert_msg(_ck_x OP _ck_y, "Assertion '%s' failed: %s == %#lx, %s == %#lx", #X" "#OP" "#Y, #X, (unsigned long)_ck_x, #Y, (unsigned long)_ck_y); \
+  ck_assert_msg(_ck_x OP _ck_y, "Assertion '%s' failed: %s == %#lx, %s == %#lx", #X" "#OP" "#Y, #X, (unsigned long)(uintptr_t)_ck_x, #Y, (unsigned long)(uintptr_t)_ck_y); \
 } while (0)
 
 /* Pointer against NULL comparison macros with improved output
@@ -1736,7 +1736,7 @@ do { \
   ck_assert_msg(_ck_x OP NULL, \
   "Assertion '%s' failed: %s == %#lx", \
   #X" "#OP" NULL", \
-  #X, (unsigned long)_ck_x); \
+  #X, (unsigned long)(uintptr_t)_ck_x); \
 } while (0)
 
 /**


### PR DESCRIPTION
A warning from pointer-to-int-cast is being thrown due to the
_ck_assert_ptr and _ck_assert_ptr_null macros casting a pointer
to an integer value (for printing), but the pointer and integer
sizes are different.

This commit first casts the pointer to a uintptr_t value before
casting it to an unsigned long.

This is the change referenced in #280 and attributed to vtorri.