### PR TITLE
Fix brew install folder permissions for osx tests

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: sudo chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: sudo chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: sudo chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install automake
       run: brew install automake
     - name: install pkg-config
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: sudo chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install automake
       run: brew install automake
     - name: install pkg-config
@@ -105,7 +105,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: sudo chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
@@ -129,7 +129,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: sudo chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -14,7 +14,7 @@ jobs:
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
-      run: brew install texi2html texinfo doxygen
+      run: brew install texi2html doxygen
     - name: install automake
       run: brew install automake
     - name: install pkg-config
@@ -37,7 +37,7 @@ jobs:
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
-      run: brew install texi2html texinfo doxygen
+      run: brew install texi2html doxygen
     - name: install automake
       run: brew install automake
     - name: install pkg-config
@@ -94,7 +94,7 @@ jobs:
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
-      run: brew install texi2html texinfo doxygen
+      run: brew install texi2html doxygen
     - name: install automake
       run: brew install automake
     - name: install pkg-config
@@ -115,7 +115,7 @@ jobs:
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
-      run: brew install texi2html texinfo doxygen
+      run: brew install texi2html doxygen
     - name: install automake
       run: brew install automake
     - name: install pkg-config

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install automake
       run: brew install automake
     - name: install pkg-config
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install automake
       run: brew install automake
     - name: install pkg-config
@@ -105,7 +105,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
@@ -129,7 +129,7 @@ jobs:
     - uses: actions/checkout@v2
     # Brew may not have permission to install its packages
     - name: change brew install folder permissions
-      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
+      run: chmod -R a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    # Brew may not have permission to install its packages
+    - name: change brew install folder permissions
+      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
@@ -34,6 +37,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    # Brew may not have permission to install its packages
+    - name: change brew install folder permissions
+      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
@@ -57,6 +63,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    # Brew may not have permission to install its packages
+    - name: change brew install folder permissions
+      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install automake
       run: brew install automake
     - name: install pkg-config
@@ -74,6 +83,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    # Brew may not have permission to install its packages
+    - name: change brew install folder permissions
+      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install automake
       run: brew install automake
     - name: install pkg-config
@@ -91,6 +103,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    # Brew may not have permission to install its packages
+    - name: change brew install folder permissions
+      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs
@@ -112,6 +127,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    # Brew may not have permission to install its packages
+    - name: change brew install folder permissions
+      run: chmod a+rwx /usr/local/share/ || mkdir -p /usr/local/share/ -m a+rwx
     - name: install maxtex
       run: brew cask install mactex
     - name: install doc programs


### PR DESCRIPTION
Recently the brew step to install texinfo stopped
working, as texinfo fails to install because it
does not have permissions to /usr/local/share