### PR TITLE
Windows: fix size prefix specifiers for printf()

### DIFF
--- a/lib/libcompat.h
+++ b/lib/libcompat.h
@@ -89,6 +89,16 @@
 #include <process.h>            /* getpid */
 #endif /* _MSC_VER */
 
+#ifdef _WIN32
+#define CK_FMT_ZU "%Iu"
+#define CK_FMT_ZD "%Id"
+#define CK_FMT_TD "%Id"
+#else
+#define CK_FMT_ZU "%zu"
+#define CK_FMT_ZD "%zd"
+#define CK_FMT_TD "%td"
+#endif
+
 /* defines size_t */
 #include <sys/types.h>
 

--- a/lib/libcompat.h
+++ b/lib/libcompat.h
@@ -89,6 +89,13 @@
 #include <process.h>            /* getpid */
 #endif /* _MSC_VER */
 
+/*
+ * On some not so old version of Visual Studio (< 2015), or with mingw-w64 not
+ * supporting POSIX printf family function, use the size prefix specifiers
+ * in msvcrt.dll. See the following link for the list of the size prefix
+ * specifiers:
+ * https://docs.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=vs-2019
+ */
 #ifdef _WIN32
 #define CK_FMT_ZU "%Iu"
 #define CK_FMT_ZD "%Id"

--- a/src/check_error.c
+++ b/src/check_error.c
@@ -61,7 +61,7 @@ void *emalloc(size_t n)
 
     p = malloc(n);
     if(p == NULL)
-        eprintf("malloc of %zu bytes failed:", __FILE__, __LINE__ - 2, n);
+        eprintf("malloc of " CK_FMT_ZU " bytes failed:", __FILE__, __LINE__ - 2, n);
     return p;
 }
 
@@ -71,6 +71,6 @@ void *erealloc(void *ptr, size_t n)
 
     p = realloc(ptr, n);
     if(p == NULL)
-        eprintf("realloc of %zu bytes failed:", __FILE__, __LINE__ - 2, n);
+        eprintf("realloc of " CK_FMT_ZU " bytes failed:", __FILE__, __LINE__ - 2, n);
     return p;
 }

--- a/src/check_pack.c
+++ b/src/check_pack.c
@@ -136,7 +136,7 @@ int pack(enum ck_msg_type type, char **buf, CheckMsg * msg)
 
     len = pftab[type] (buf, msg);
     if(len > (size_t) INT_MAX)
-        eprintf("Value of len (%zu) too big, max allowed %u\n",
+        eprintf("Value of len (" CK_FMT_ZU ") too big, max allowed %u\n",
                 __FILE__, __LINE__ - 3, len, INT_MAX);
     return (int) len;
 }
@@ -159,10 +159,10 @@ int upack(char *buf, CheckMsg * msg, enum ck_msg_type *type)
 
     diff = buf - obuf;
     if(diff > (ptrdiff_t) INT_MAX)
-        eprintf("Value of diff (%td) too big, max allowed %d\n",
+        eprintf("Value of diff (" CK_FMT_TD ") too big, max allowed %d\n",
                 __FILE__, __LINE__ - 3, diff, INT_MAX);
     if(diff > (ptrdiff_t) INT_MAX || diff < (ptrdiff_t) INT_MIN)
-        eprintf("Value of diff (%td) too small, min allowed %d\n",
+        eprintf("Value of diff (" CK_FMT_TD ") too small, min allowed %d\n",
                 __FILE__, __LINE__ - 6, diff, INT_MIN);
     return (int) diff;
 }
@@ -203,7 +203,7 @@ static void pack_str(char **buf, const char *val)
     else
         strsz = strlen(val);
     if(strsz > CK_UINT32_MAX)
-        eprintf("Value of strsz (%zu) too big, max allowed %u\n",
+        eprintf("Value of strsz (" CK_FMT_ZU ") too big, max allowed %u\n",
                 __FILE__, __LINE__, strsz, CK_UINT32_MAX);
 
     pack_int(buf, (ck_uint32) strsz);

--- a/tests/check_check_master.c
+++ b/tests/check_check_master.c
@@ -908,7 +908,7 @@ void record_failure_line_num(int linenum)
   written = fwrite(string, 1, to_write, line_num_failures);
   if(written != to_write)
   {
-    fprintf(stderr, "%s:%d: Error in call to fwrite, wrote %zd instead of %zu:", __FILE__, __LINE__, written, to_write);
+    fprintf(stderr, "%s:%d: Error in call to fwrite, wrote " CK_FMT_ZD " instead of " CK_FMT_ZU ":", __FILE__, __LINE__, written, to_write);
     exit(1);
   }
 


### PR DESCRIPTION
On Windows (mingw(-w64) and old Visual Studio, %z and %t are not
supported. Use the size prefix specifiers for printf  in msvcrt.dll. See :
https://docs.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=vs-2019