### PR TITLE
Replace uses of add-path

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,9 +67,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: add mingw to path
-      run: echo "::add-path::C:\msys64\mingw64\bin"
+      run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
     - name: add mingw to path
-      run: echo "::add-path::C:\msys64\usr\bin"
+      run: echo "C:\msys64\usr\bin" >> $GITHUB_PATH
     - name: autoreconf
       run: bash -c "autoreconf -i"
     - name: configure


### PR DESCRIPTION
Using add-path to update the current path is being deprecated:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This commit updates the Windows workflows to use the new mechanism