### PR TITLE
Re-format GitHub readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
-# About Check
+<div align="center">
+
+# Check
 
 [![Linux Build Status](https://github.com/libcheck/check/workflows/linux/badge.svg)](https://github.com/libcheck/check/actions?query=workflow%3Alinux)
 [![OSX Build Status](https://github.com/libcheck/check/workflows/osx/badge.svg)](https://github.com/libcheck/check/actions?query=workflow%3Aosx)
 [![Windows Build Status](https://github.com/libcheck/check/workflows/windows/badge.svg)](https://github.com/libcheck/check/actions?query=workflow%3Awindows)
 
+</div>
+
+## Table of Contents
+ * [About](#about)
+ * [Installing](#installing)
+ * [Linking](#linking)
+ * [Packaging](#packaging)
+
+## About
 
 Check is a unit testing framework for C. It features a simple interface
 for defining unit tests, putting little in the way of the
@@ -15,7 +26,7 @@ source code editors and IDEs.
 See https://libcheck.github.io/check for more information, including a
 tutorial.  The tutorial is also available as `info check`.
 
-# Installation
+## Installing
 
 Check has the following dependencies:
 
@@ -29,7 +40,7 @@ Check has the following dependencies:
 
 The versions specified may be higher than those actually needed.
 
-## autoconf
+### autoconf
 
     $ autoreconf --install
     $ ./configure
@@ -45,7 +56,7 @@ you ever change something during development, run autoreconf again
 necessary.  Check is installed to `/usr/local/lib` by default. ldconfig rebuilds
 the linker cache so that newly installed library file is included in the cache.
 
-## cmake
+### cmake
 
     $ mkdir build
     $ cd build
@@ -53,14 +64,14 @@ the linker cache so that newly installed library file is included in the cache.
     $ make
     $ CTEST_OUTPUT_ON_FAILURE=1 make test
 
-# Linking against Check
+## Linking
 
 Check uses variadic macros in check.h, and the strict C90 options for
 gcc will complain about this.  In gcc 4.0 and above you can turn this
 off explicitly with `-Wno-variadic-macros`.  In a future API it would be
 nice to eliminate these macros.
 
-# Packaging
+## Packaging
 
 Check is available packaged for the following operating systems:
 

--- a/README.md
+++ b/README.md
@@ -75,5 +75,8 @@ nice to eliminate these macros.
 
 Check is available packaged for the following operating systems:
 
+<div align="center">
+
 [![Packaging status](https://repology.org/badge/vertical-allrepos/check.svg)](https://repology.org/project/check/versions)
 
+</div>


### PR DESCRIPTION
## Description
The changes in this pull request are purely aesthetic, and the only changed file is `README.md`.

 * Centered the project title and the status badges
 * Created a Table of Contents
 * Centered the Repology status widget
 * Standardized header wording and enumeration

## About
I used [this template](https://github.com/kylelobo/The-Documentation-Compendium/blob/master/en/README_TEMPLATES/Hackathon.md) from [the Documentation Compendium](https://github.com/kylelobo/The-Documentation-Compendium) project as the inspiration for these changes, but the actual additions/modifications are minimal, as this is my first pull request and I wanted to start out with something small but impactful, yet definitely bug-free :upside_down_face: .

---
## Preview
A full, live preview of the changes in this pull request, can be viewed [here](https://github.com/jflopezfernandez/check/tree/docs/format-github-readme).

![New README.md format](https://imgur.com/A6nEU0J.png)