### PR TITLE
Fix GitHub Pages Site Download Bug #10

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ http://creativecommons.org/licenses/by-nc/2.5/
 
 <ul id="navlist">
 <li id="active"><a href="#" id="current">Home</a></li>
-<li><a href="./NEWS">NEWS</a></li>
+<li><a href="https://raw.githubusercontent.com/libcheck/check/master/NEWS">NEWS</a></li>
 <li><a href="./web/install.html">Install</a></li>
 <li><a href="./doc/doxygen/html/check_8h.html">API</a></li>
 <li><a href="./doc/check_html/check_3.html">Tutorial</a></li>
@@ -58,15 +58,15 @@ http://creativecommons.org/licenses/by-nc/2.5/
 <!-- Update this section during a release -->
 <b>August 7, 2020:</b> Check 0.15.2 <a href="https://github.com/libcheck/check/releases">
 is now available for download</a>. Check is available under the
-<a href="./COPYING.LESSER">LGPL license</a>. New features available in
-this release are listed on the <a href="./NEWS">NEWS</a> page.
+<a href="https://github.com/libcheck/check/blob/master/COPYING.LESSER">LGPL license</a>. New features available in
+this release are listed on the <a href="https://raw.githubusercontent.com/libcheck/check/master/NEWS">NEWS</a> page.
 </p>
 
 <h3>About Project</h3>
 <p>
 <ul>
 <li><a href="https://github.com/libcheck/check">Project Page</a></li>
-<li><a href="./COPYING.LESSER">LGPL License</a></li>
+<li><a href="https://github.com/libcheck/check/blob/master/COPYING.LESSER">LGPL License</a></li>
 <li><a href="./web/users-of-check.html">Users of Check</a></li>
 <li><a href="https://lists.sourceforge.net/lists/listinfo/check-users">Mailing list</a></li>
 <li><a href="https://buildfarm.opencsw.org/buildbot/waterfall?builder=libcheck-solaris10-amd64&builder=libcheck-solaris10-i386&builder=libcheck-solaris10-sparc&builder=libcheck-solaris10-sparcv9&reload=6">OpenCSW BuildBot</a></li>


### PR DESCRIPTION
## Commit
As the related issue documents, GitHub pages cannot
determine the file type of the NEWS or LGPL files because
they do not have a file extension, so the server uses a
default MIME type of application/octet-stream, which
triggers a download, rather than letting the user actually
read the file.

To circumvent this problem, I changed to file links from
relative links to full hyperlinks referencing the GitHub
repository URL instead. The NEWS file is now viewable via
the "raw" view option accessible through GitHub, and the
LGPL file links to the GitHub license file default.

I chose not to simply use the raw view for the license file
since I felt most people looking at that file would
probably not be lawyers, and would therefore benefit from
the summary GitHub displays at the top of the page.

## Notes
I tested the links using the Firefox web developer tools.

---

This pull request fixes issue #10
Pull request #308 incorrectly attempted to merge change to master and has been deleted