### PR TITLE
Fixed wrong function replacement

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,7 +110,7 @@ endif(NOT HAVE_SNPRINTF)
 
 if(NOT HAVE_DECL_STRDUP AND NOT HAVE__STRDUP)
   target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/strdup.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/snprintf.c)
+  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/strdup.c)
 endif(NOT HAVE_DECL_STRDUP AND NOT HAVE__STRDUP)
 
 if(NOT HAVE_DECL_STRSIGNAL)


### PR DESCRIPTION
The current version of the Check CMake configuration replaces the `strdup` function with different source files depending on whether we are building a shared or static version of the library.