### PR TITLE
Docs/create community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: There are no bugs here. But just in case...
+
+---
+# Bug Report
+Thank you for filing a bug report! The more information you
+can give us about your development environment, toolchain,
+actions leading up to the bug, or any other contextual
+information, the faster we'll be able to verify and diagnose
+what went wrong.
+
+At a minimun, please be sure to include the library version
+you were working with. If you were trying to compile it from
+source, please be sure to specify the compiler, compiler
+version, operating system, operating system version, the
+build system you used to generate the project, and whether
+you were building from a source distribution or from version
+control.
+
+If you have no idea what any or all of the above terms mean,
+you are always welcome to submit a bug report anyways, but
+please remember the Fundamental Theorem of Bug Report
+Submissions:
+
+ > The amount of information in a bug report is directly
+ proportional to its resolution speed.
+
+## Checklist
+Please do your best to include the following items with your
+bug report.
+
+### The Bare Minimum
+Remember that this is the **minimum** required information.
+More is always more helpful.
+
+ - [ ] [libcheck](https://github.com/libcheck/check) version
+ - [ ] Operating system
+ - [ ] Compiler
+
+## Additional Information
+Please be sure to include any additional information you
+think may be helpful in helping us diagnose, understand, or
+replicate the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Check Library Users Mailing List
+    url: check-users@sourceforge.net
+    about: User questions are accepted and welcome!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: Check Library Users Mailing List
-    url: check-users@sourceforge.net
-    about: User questions are accepted and welcome!


### PR DESCRIPTION
I created an `ISSUE_TEMPLATE` directory in the `.github` project directory to allow us to pre-populate bug-report related issues and speed up the turnaround time by being able to skip the information request phase, letting us get right into the verification, diagnosis, fix, and test phases.