### PR TITLE
docs: fix simple typo, inproperly -> improperly

### DIFF
--- a/tests/check_check_sub.c
+++ b/tests/check_check_sub.c
@@ -2677,7 +2677,7 @@ END_TEST
 
 /*
  * The following test will leak memory because it is calling
- * APIs inproperly. The leaked memory cannot be free'd, as
+ * APIs improperly. The leaked memory cannot be free'd, as
  * the methods to do so are static. (No user of Check should
  * call them directly).
  */


### PR DESCRIPTION
There is a small typo in tests/check_check_sub.c.

Should read `improperly` rather than `inproperly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md