### PR TITLE
Corrected check-users email address in HTML pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@ per platform.
 
 <p>
 Questions are accepted on the mailing list
-<a href="https://lists.sourceforge.net/lists/listinfo/check-users">check-users@sourceforge.net</a>
+<a href="https://lists.sourceforge.net/lists/listinfo/check-users">check-users AT lists.sourceforge.net</a>
 and bugs and feature requests can be submitted via the Github
 page <a href="https://github.com/libcheck/check/issues">here</a>.
 </p>

--- a/web/users-of-check.html
+++ b/web/users-of-check.html
@@ -86,7 +86,7 @@ http://creativecommons.org/licenses/by-nc/2.5/
 <p>
 If you're using Check for an open source project and you're not listed
 here, please send am email to our mailing list
-<a href="https://lists.sourceforge.net/lists/listinfo/check-users">check-users@sourceforge.net</a>,
+<a href="https://lists.sourceforge.net/lists/listinfo/check-users">check-users AT lists.sourceforge.net</a>,
 and we'll list you promptly.
 </p>
 </div>


### PR DESCRIPTION
`check-users@sourceforge.net` isn't the write email address for the mailing list!

I have corrected it to `lists.sourceforge.net` but also changed the `@` to ` AT ` as a weak attempt to prevent spam.
