### PR TITLE
Add JUnit XML support

### DIFF
--- a/doc/check.texi
+++ b/doc/check.texi
@@ -1930,6 +1930,8 @@ of to a file.
 @findex srunner_set_xml
 @findex srunner_has_xml
 @findex srunner_xml_fname
+@findex srunner_xml_format
+@findex srunner_set_xml_format
 The log can also be written in XML.  The following functions define
 the interface for XML logs:
 @example
@@ -1937,6 +1939,8 @@ the interface for XML logs:
 void srunner_set_xml (SRunner *sr, const char *fname);
 int srunner_has_xml (SRunner *sr);
 const char *srunner_xml_fname (SRunner *sr);
+enum xml_format srunner_xml_format(SRunner * sr);
+void srunner_set_xml_format(SRunner * sr, enum xml_format format);
 @end verbatim
 @end example
 
@@ -2047,6 +2051,59 @@ of to a file.
 If both plain text and XML log files are specified, by any of above methods,
 then check will log to both files. In other words logging in plain text and XML
 format simultaneously is supported.
+
+JUnit Support is also available.  It is enabled  by a call to 
+@code{srunner_set_xml_format(CK_XML_FORMAT_JUNIT)} before the tests are run. 
+It can also be enabled by environment variable as well.  It is enabled by setting the
+@code{CK_XML_FORMAT_NAME} environment variable to @code{junit}.
+
+Here is an example of the JUnit xml format:
+@example
+@verbatim
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="8" errors="1" failures="4">
+  <testsuite name="S1" tests="3" errors="1" failures="1">
+    <testcase classname="Core" name="test_pass">
+    </testcase>
+    <testcase classname="Core" name="test_fail">
+      <failure message="Failure">
+        Core:test_fail:0
+        ex_output.c:37
+        Failure
+      </failure>
+    </testcase>
+    <testcase classname="Core" name="test_exit">
+      <error message="Early exit with return value 1">
+        Core:test_exit:0
+        ex_output.c:46
+        Early exit with return value 1
+      </error>
+    </testcase>
+  </testsuite>
+  <testsuite name="S2" tests="4" errors="0" failures="2">
+    <testcase classname="Core" name="test_pass2">
+    </testcase>
+    <testcase classname="Core" name="test_loop">
+      <failure message="Iteration 0 failed">
+        Core:test_loop:0
+        ex_output.c:72
+        Iteration 0 failed
+      </failure>
+    </testcase>
+    <testcase classname="Core" name="test_loop">
+    </testcase>
+    <testcase classname="Core" name="test_loop">
+      <failure message="Iteration 2 failed">
+        Core:test_loop:2
+        ex_output.c:72
+        Iteration 2 failed
+      </failure>
+    </testcase>
+  </testsuite>
+</testsuites>
+@end verbatim
+@end example
+
 
 @node TAP Logging,  , Test Logging, Test Logging
 @subsection TAP Logging

--- a/src/check.c
+++ b/src/check.c
@@ -156,6 +156,7 @@ TCase *tcase_create(const char *name)
     tc->unch_tflst = check_list_create();
     tc->ch_tflst = check_list_create();
     tc->tags = check_list_create();
+    tc->s = NULL;
 
     return tc;
 }
@@ -246,6 +247,7 @@ void suite_add_tcase(Suite * s, TCase * tc)
     {
         return;
     }
+    tc->s = s;
 
     check_list_add_end(s->tclst, tc);
 }
@@ -531,7 +533,7 @@ static void tr_init(TestResult * tr)
     tr->rtype = CK_TEST_RESULT_INVALID;
     tr->msg = NULL;
     tr->file = NULL;
-    tr->tcname = NULL;
+    tr->tc = NULL;
     tr->tname = NULL;
     tr->duration = -1;
 }
@@ -571,7 +573,7 @@ enum ck_result_ctx tr_ctx(TestResult * tr)
 
 const char *tr_tcname(TestResult * tr)
 {
-    return tr->tcname;
+    return tr->tc->name;
 }
 
 static enum fork_status _fstat = CK_FORK;

--- a/src/check.h.in
+++ b/src/check.h.in
@@ -2262,6 +2262,48 @@ CK_DLL_EXP int CK_EXPORT srunner_has_tap(SRunner * sr);
 CK_DLL_EXP const char *CK_EXPORT srunner_tap_fname(SRunner * sr);
 
 /**
+ * enum describing the specific XML format used for XML logging
+ */
+enum xml_format {
+    CK_XML_FORMAT_UNSPECIFIED,
+    CK_XML_FORMAT_DEFAULT,      // the default (original) format
+    CK_XML_FORMAT_JUNIT,        // output in JUnit compatible XML
+};
+
+/**
+ * Returns the XML format used if XML is to be logged.
+ *
+ * This value can be explicitly set via `srunner_set_xml_format` or can
+ * be set via the CK_XML_FORMAT_NAME environment variable.  
+ *
+ * @return CK_XML_FORMAT_DEFAULT unless the format is explicitly set via
+ *         `srunner_set_xml_format(sr, CK_XML_FORMAT_JUNIT)` or
+ *         `getenv("CK_XML_FORMAT_NAME")` returns "unit"
+ *
+ * @param sr suite runner to check
+ *
+ * @since 0.15.3.
+ */
+CK_DLL_EXP enum xml_format CK_EXPORT srunner_xml_format(SRunner * sr);
+
+/**
+ * Set the suite runner to output the result in an XML format compatible
+ * with JUnit's XML format.
+ *
+ * Note: XML format setting is an initialize only operation -- it should
+ * be done immediately after SRunner creation, and the XML format can't be
+ * changed after being set.
+ *
+ * This setting does not afffect the other log output types.
+ *
+ * @param sr suite runner to log results of in XML format
+ * @param format the xml_format to use
+ *
+ * @since 0.15.3
+*/
+CK_DLL_EXP void CK_EXPORT srunner_set_xml_format(SRunner * sr, enum xml_format format);
+
+/**
  * Enum describing the current fork usage.
  */
 enum fork_status

--- a/src/check_impl.h
+++ b/src/check_impl.h
@@ -59,6 +59,7 @@ struct TCase
 {
     const char *name;
     struct timespec timeout;
+    struct Suite *s;
     List *tflst;                /* list of test functions */
     List *unch_sflst;
     List *unch_tflst;
@@ -82,7 +83,7 @@ struct TestResult
     int line;                   /* Line number where the test occurred */
     int iter;                   /* The iteration value for looping tests */
     int duration;               /* duration of this test in microseconds */
-    const char *tcname;         /* Test case that generated the result */
+    TCase *tc;                  /* Test case that generated the result */
     const char *tname;          /* Test that generated the result */
     char *msg;                  /* Failure message */
 };
@@ -121,6 +122,7 @@ struct SRunner
     List *resultlst;            /* List of unit test results */
     const char *log_fname;      /* name of log file */
     const char *xml_fname;      /* name of xml output file */
+    enum xml_format xml_format;
     const char *tap_fname;      /* name of tap output file */
     List *loglst;               /* list of Log objects */
     enum fork_status fstat;     /* controls if suites are forked or not

--- a/src/check_log.h
+++ b/src/check_log.h
@@ -37,6 +37,9 @@ void lfile_lfun(SRunner * sr, FILE * file, enum print_output,
 void xml_lfun(SRunner * sr, FILE * file, enum print_output,
               void *obj, enum cl_event evt);
 
+void junit_lfun(SRunner * sr, FILE * file, enum print_output,
+              void *obj, enum cl_event evt);
+
 void tap_lfun(SRunner * sr, FILE * file, enum print_output,
               void *obj, enum cl_event evt);
 

--- a/src/check_print.c
+++ b/src/check_print.c
@@ -237,7 +237,6 @@ void tr_junitprint(FILE * file, TestResult * tr,
                  enum print_output print_mode CK_ATTRIBUTE_UNUSED)
 {
     char status[10];
-    char type[10];
     char *path_name = NULL;
     char *file_name = NULL;
     char *slash = NULL;
@@ -302,6 +301,7 @@ void tr_junitprint(FILE * file, TestResult * tr,
           fprintf(file, "      </%s>\n", status);
     }
     fprintf(file, "    </testcase>\n");
+    free(path_name);
 }
 
 enum print_output get_env_printmode(void)

--- a/src/check_print.h
+++ b/src/check_print.h
@@ -25,6 +25,7 @@
 void fprint_xml_esc(FILE * file, const char *str);
 void tr_fprint(FILE * file, TestResult * tr, enum print_output print_mode);
 void tr_xmlprint(FILE * file, TestResult * tr, enum print_output print_mode);
+void tr_junitprint(FILE * file, TestResult * tr, enum print_output print_mode);
 void srunner_fprint(FILE * file, SRunner * sr, enum print_output print_mode);
 enum print_output get_env_printmode(void);
 

--- a/src/check_str.c
+++ b/src/check_str.c
@@ -41,7 +41,7 @@ char *tr_str(TestResult * tr)
 
     rstr = ck_strdup_printf("%s:%d:%s:%s:%s:%d: %s%s",
                             tr->file, tr->line,
-                            tr_type_str(tr), tr->tcname, tr->tname, tr->iter,
+                            tr_type_str(tr), tr->tc->name, tr->tname, tr->iter,
                             exact_msg, tr->msg);
 
     return rstr;

--- a/tests/check_check_log.c
+++ b/tests/check_check_log.c
@@ -200,6 +200,55 @@ START_TEST(test_double_set_xml)
 }
 END_TEST
 
+START_TEST(test_default_xml_format) {
+  Suite *s = suite_create("Suite");
+  SRunner *sr = srunner_create(s);
+  ck_assert_msg(srunner_xml_format(sr) == CK_XML_FORMAT_DEFAULT,
+                "XML format is not default");
+  srunner_free(sr);
+}
+END_TEST
+
+START_TEST(test_set_xml_format) {
+  Suite *s = suite_create("Suite");
+  SRunner *sr = srunner_create(s);
+  srunner_set_xml_format(sr, CK_XML_FORMAT_JUNIT);
+  ck_assert_msg(srunner_xml_format(sr) == CK_XML_FORMAT_JUNIT,
+                "XML format is not Junit");
+  srunner_free(sr);
+}
+END_TEST
+
+#if HAVE_DECL_SETENV
+/* Test enabling JUnit XML format logging via environment variable */
+START_TEST(test_set_xml_format_env)
+{
+  const char *old_val;
+  Suite *s = suite_create("Suite");
+  SRunner *sr = srunner_create(s);
+
+  /* check that setting XML format via environment variable works */
+  ck_assert_msg(save_set_env("CK_XML_FORMAT_NAME", "junit", &old_val) == 0,
+              "Failed to set environment variable");
+
+  ck_assert_msg(srunner_xml_format(sr) == CK_XML_FORMAT_JUNIT,
+                "SRunner not set to use Junit");
+
+  /* check that explicit call to srunner_set_xml_format() overrides environment
+   * variable */
+  srunner_set_xml_format(sr, CK_XML_FORMAT_DEFAULT);
+  ck_assert_msg(srunner_xml_format(sr) == CK_XML_FORMAT_DEFAULT,
+                "SRunner not using explicitly set XML format");
+
+  /* restore old environment */
+  ck_assert_msg(restore_env("CK_XML_FORMAT_NAME", old_val) == 0,
+              "Failed to restore environment variable");
+  
+  srunner_free(sr);
+}
+END_TEST
+#endif /* HAVE_DECL_SETENV */
+
 START_TEST(test_set_tap)
 {
   Suite *s = suite_create("Suite");
@@ -301,6 +350,12 @@ Suite *make_log_suite(void)
 #endif /* HAVE_DECL_SETENV */
   tcase_add_test(tc_core_xml, test_no_set_xml);
   tcase_add_test(tc_core_xml, test_double_set_xml);
+
+  tcase_add_test(tc_core_xml, test_default_xml_format);
+  tcase_add_test(tc_core_xml, test_set_xml_format);
+#if HAVE_DECL_SETENV
+  tcase_add_test(tc_core_xml, test_set_xml_format_env);
+#endif
 
   suite_add_tcase(s, tc_core_tap);
   tcase_add_test(tc_core_tap, test_set_tap);

--- a/tests/ex_output.c
+++ b/tests/ex_output.c
@@ -136,7 +136,7 @@ static void print_usage(void)
     printf(" | CK_SUBUNIT");
 #endif
     printf(")\n");
-    printf("                 (STDOUT | STDOUT_DUMP | LOG | LOG_STDOUT | TAP | TAP_STDOUT | XML | XML_STDOUT)\n");
+    printf("                 (STDOUT | STDOUT_DUMP | LOG | LOG_STDOUT | TAP | TAP_STDOUT | XML | XML_STDOUT | JUNIT_XML | JUNIT_XML_STDOUT )\n");
     printf("                 (NORMAL | EXIT_TEST)\n");
     printf("   If CK_ENV is used, the environment variable CK_VERBOSITY can be set to\n");
     printf("   one of these: silent, minimal, or verbose. If it is not set to these, or\n");
@@ -189,6 +189,16 @@ static void run_tests(enum print_output printmode, char *log_type, int include_e
     else if(strcmp(log_type, "XML_STDOUT") == 0)
     {
         srunner_set_xml(sr, "-");
+    }
+    else if(strcmp(log_type, "JUNIT_XML") == 0)
+    {
+        srunner_set_xml(sr, "junit_test.xml");
+        srunner_set_xml_format(sr, CK_XML_FORMAT_JUNIT);
+    }
+    else if(strcmp(log_type, "JUNIT_XML_STDOUT") == 0)
+    {
+        srunner_set_xml(sr, "-");
+        srunner_set_xml_format(sr, CK_XML_FORMAT_JUNIT);
     }
     else
     {

--- a/tests/test_junit_xml_output.sh
+++ b/tests/test_junit_xml_output.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+
+OUTPUT_FILE=junit_test.xml
+CK_DEFAULT_TIMEOUT=4
+
+. ./test_vars
+. $(dirname $0)/test_output_strings
+
+rm -f ${OUTPUT_FILE}
+export CK_DEFAULT_TIMEOUT
+./ex_output${EXEEXT} CK_MINIMAL JUNIT_XML NORMAL > /dev/null
+actual_junit_xml=`cat ${OUTPUT_FILE} | tr -d "\r" | grep -v \<duration\> | grep -v \<datetime\> | grep -v \<path\>`
+if [ x"${expected_junit_xml}" != x"${actual_junit_xml}" ]; then
+    echo "Problem with ex_xml_output${EXEEXT}";
+    echo "Expected:";
+    echo "${expected_junit_xml}";
+    echo "Got:";
+    echo "${actual_junit_xml}";
+    exit 1;
+fi
+
+if [ ! -z `which xmllint` ]; then
+    xmllint_output=`xmllint ${OUTPUT_FILE}`
+    if [ $? -ne 0 ]; then
+        echo "xmllint found an issue"
+        echo ${xmllint_output}
+        exit 1
+    fi
+fi
+
+exit 0

--- a/tests/test_output.sh
+++ b/tests/test_output.sh
@@ -59,6 +59,8 @@ tap_stdout=`                             ./ex_output${EXEEXT} CK_SILENT TAP_STDO
 tap_env_stdout=`CK_TAP_LOG_FILE_NAME="-" ./ex_output${EXEEXT} CK_SILENT STDOUT NORMAL`
 xml_stdout=`                             ./ex_output${EXEEXT} CK_SILENT XML_STDOUT NORMAL  | tr -d "\r" | grep -v \<duration\> | grep -v \<datetime\> | grep -v \<path\>`
 xml_env_stdout=`CK_XML_LOG_FILE_NAME="-" ./ex_output${EXEEXT} CK_SILENT STDOUT NORMAL      | tr -d "\r" | grep -v \<duration\> | grep -v \<datetime\> | grep -v \<path\>`
+junit_xml_stdout=`                             ./ex_output${EXEEXT} CK_SILENT JUNIT_XML_STDOUT NORMAL  | tr -d "\r" | grep -v \<duration\> | grep -v \<datetime\> | grep -v \<path\>`
+junit_xml_env_stdout=`CK_XML_LOG_FILE_NAME="-" CK_XML_FORMAT_NAME="junit" ./ex_output${EXEEXT} CK_SILENT STDOUT NORMAL`
 
 test_output ( ) {
     if [ "x${1}" != "x${2}" ]; then
@@ -92,6 +94,8 @@ test_output "${expected_log_log}"    "${log_stdout}"     "CK_SILENT LOG_STDOUT N
 test_output "${expected_log_log}"    "${log_env_stdout}" "CK_SILENT STDOUT     NORMAL (with log env = '-')"
 test_output "${expected_xml}"        "${xml_stdout}"     "CK_SILENT XML_STDOUT NORMAL"
 test_output "${expected_xml}"        "${xml_env_stdout}" "CK_SILENT STDOUT     NORMAL (with xml env = '-')"
+test_output "${expected_junit_xml}"        "${junit_xml_stdout}"     "CK_SILENT JUNIT_XML_STDOUT NORMAL"
+test_output "${expected_junit_xml}"        "${junit_xml_env_stdout}" "CK_SILENT STDOUT     NORMAL (with junit_xml env = '-')"
 test_output "${expected_normal_tap}" "${tap_stdout}"     "CK_SILENT TAP_STDOUT NORMAL"
 test_output "${expected_normal_tap}" "${tap_env_stdout}" "CK_SILENT STDOUT     NORMAL (with tap env = '-')"
 

--- a/tests/test_output_strings
+++ b/tests/test_output_strings
@@ -294,6 +294,60 @@ expected_duration_count=8
 fi
 
 ##################
+# junit xml output
+##################
+expected_junit_xml="<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<testsuites tests=\"8\" errors=\"1\" failures=\"4\">
+  <testsuite name=\"S1\" tests=\"3\" errors=\"1\" failures=\"1\">
+    <testcase classname=\"Core\" name=\"test_pass\">
+    </testcase>
+    <testcase classname=\"Core\" name=\"test_fail\">
+      <failure message=\"Failure\">
+        Core:test_fail:0
+        ex_output.c:37
+        Failure
+      </failure>
+    </testcase>
+    <testcase classname=\"Core\" name=\"test_exit\">
+      <error message=\"Early exit with return value 1\">
+        Core:test_exit:0
+        ex_output.c:46
+        Early exit with return value 1
+      </error>
+    </testcase>
+  </testsuite>
+  <testsuite name=\"S2\" tests=\"4\" errors=\"0\" failures=\"2\">
+    <testcase classname=\"Core\" name=\"test_pass2\">
+    </testcase>
+    <testcase classname=\"Core\" name=\"test_loop\">
+      <failure message=\"Iteration 0 failed\">
+        Core:test_loop:0
+        ex_output.c:72
+        Iteration 0 failed
+      </failure>
+    </testcase>
+    <testcase classname=\"Core\" name=\"test_loop\">
+    </testcase>
+    <testcase classname=\"Core\" name=\"test_loop\">
+      <failure message=\"Iteration 2 failed\">
+        Core:test_loop:2
+        ex_output.c:72
+        Iteration 2 failed
+      </failure>
+    </testcase>
+  </testsuite>
+  <testsuite name=\"XML escape &quot; &apos; &lt; &gt; &amp; &#x9; &#xA;X tests\" tests=\"1\" errors=\"0\" failures=\"1\">
+    <testcase classname=\"description &quot; &apos; &lt; &gt; &amp; &#x9; &#xA;X end\" name=\"test_xml_esc_fail_msg\">
+      <failure message=\"fail &quot; &apos; &lt; &gt; &amp; &#x9; &#xA;X message\">
+        description &quot; &apos; &lt; &gt; &amp; &#x9; &#xA;X end:test_xml_esc_fail_msg:0
+        ex_output.c:78
+        fail &quot; &apos; &lt; &gt; &amp; &#x9; &#xA;X message
+      </failure>
+    </testcase>
+  </testsuite>
+</testsuites>"
+
+##################
 # tap output
 ##################
 if [ $HAVE_FORK -eq 1 ]; then


### PR DESCRIPTION
* Added an srunner_set_xml_format function and also an CK_XML_FORMAT_NAME environment variable to select JUnit formatting
* Test timings are not supported at this time
* Add tests to cover new functionality
* Update documentation

The implementation was inspired by Glenn Washburn's original patches.

references -
Original Patches - https://sourceforge.net/p/check/mailman/message/2963561/
Issue #334 