### PR TITLE
Update CMake required from 3.9 to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 #
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 include(CheckCCompilerFlag)
 


### PR DESCRIPTION
https://github.com/libcheck/check/issues/325

    cmake_minimum_required(...) is version 3.9 required in top level CMakeLists.txt, In this file, the funcion add_link_options(...) is invoked at line 251 and it`s news from CMAKE version 3.13.