### PR TITLE
Allow disabling autodetection of subunit library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,7 +393,13 @@ if (HAVE_LIBRT)
   ADD_DEFINITIONS(-DHAVE_LIBRT=1)
 endif (HAVE_LIBRT)
 
-check_library_exists(subunit subunit_test_start "" HAVE_SUBUNIT)
+# Allow disabling subunit
+IF(ENABLE_SUBUNIT_EXT)
+  check_library_exists(subunit subunit_test_start "" HAVE_SUBUNIT)
+ELSE(ENABLE_SUBUNIT_EXT)
+  set(HAVE_SUBUNIT, false)
+ENDIF(ENABLE_SUBUNIT_EXT)
+
 if (HAVE_SUBUNIT)
   set(SUBUNIT "subunit")
   set(ENABLE_SUBUNIT 1)


### PR DESCRIPTION
It can be useful to avoid linking to subunit when we are building the check library for the host, e.g. in a buildroot recipe, where the built check is linked into other applications which are used on the host to build images.

These applications are built with the host's cross-compiler and can use the host's pkgconfig to determine if libraries are available. When check is linked against other libraries, it can fail this check for subunit.

Allow disabling the autodetection of subunit with a configure flag -DENABLE_SUBUNIT_EXT=OFF