### PR TITLE
src/check_run.c: fix build on noMMU platforms

### DIFF
--- a/src/check_run.c
+++ b/src/check_run.c
@@ -772,12 +772,12 @@ void srunner_run_tagged(SRunner * sr, const char *sname, const char *tcname,
                         const char *include_tags, const char *exclude_tags,
                         enum print_output print_mode)
 {
-#if defined(HAVE_SIGACTION) && defined(HAVE_FORK)
+#if defined(HAVE_SIGACTION) && defined(HAVE_FORK) && HAVE_FORK==1
     static struct sigaction sigalarm_old_action;
     static struct sigaction sigalarm_new_action;
     static struct sigaction sigint_new_action;
     static struct sigaction sigterm_new_action;
-#endif /* HAVE_SIGACTION && HAVE_FORK */
+#endif /* HAVE_SIGACTION && HAVE_FORK && HAVE_FORK==1 */
 
     /*  Get the selected test suite and test case from the
        environment.  */
@@ -797,7 +797,7 @@ void srunner_run_tagged(SRunner * sr, const char *sname, const char *tcname,
         eprintf("Bad print_mode argument to srunner_run_all: %d",
                 __FILE__, __LINE__, print_mode);
     }
-#if defined(HAVE_SIGACTION) && defined(HAVE_FORK)
+#if defined(HAVE_SIGACTION) && defined(HAVE_FORK) && HAVE_FORK==1
     memset(&sigalarm_new_action, 0, sizeof(sigalarm_new_action));
     sigalarm_new_action.sa_handler = sig_handler;
     sigaction(SIGALRM, &sigalarm_new_action, &sigalarm_old_action);
@@ -809,16 +809,16 @@ void srunner_run_tagged(SRunner * sr, const char *sname, const char *tcname,
     memset(&sigterm_new_action, 0, sizeof(sigterm_new_action));
     sigterm_new_action.sa_handler = sig_handler;
     sigaction(SIGTERM, &sigterm_new_action, &sigterm_old_action);
-#endif /* HAVE_SIGACTION && HAVE_FORK */
+#endif /* HAVE_SIGACTION && HAVE_FORK && HAVE_FORK==1 */
     srunner_run_init(sr, print_mode);
     srunner_iterate_suites(sr, sname, tcname, include_tags, exclude_tags,
                            print_mode);
     srunner_run_end(sr, print_mode);
-#if defined(HAVE_SIGACTION) && defined(HAVE_FORK)
+#if defined(HAVE_SIGACTION) && defined(HAVE_FORK) && HAVE_FORK==1
     sigaction(SIGALRM, &sigalarm_old_action, NULL);
     sigaction(SIGINT, &sigint_old_action, NULL);
     sigaction(SIGTERM, &sigterm_old_action, NULL);
-#endif /* HAVE_SIGACTION && HAVE_FORK */
+#endif /* HAVE_SIGACTION && HAVE_FORK && HAVE_FORK==1 */
 }
 
 void srunner_run(SRunner * sr, const char *sname, const char *tcname,


### PR DESCRIPTION
src/check_run.c defines sig_handler() under the following conditions:

  #if defined(HAVE_FORK) && HAVE_FORK==1

however, it does use sig_handler under the following conditions:

  #if defined(HAVE_SIGACTION) && defined(HAVE_FORK)

which breaks when HAVE_FORK is defined, but has the value HAVE_FORK=0, as is the case on noMMU platforms.

This commit fixes this by ensuring that the build conditions are aligned throughout check_run.c.

Fixes:

src/check_run.c: In function 'srunner_run_tagged': src/check_run.c:802:38: error: 'sig_handler' undeclared (first use in this function); did you mean 'sa_handler'? [...]