### PR TITLE
src/CMakeLists.txt: don't build shared libraries when not enabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,56 @@ set(SOURCES
   check_run.c
   check_str.c)
 
+# Add parts of libcompat as required
+list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/fpclassify.c)
+
+if (NOT HAVE_LIBRT)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/clock_gettime.c)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/timer_create.c)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/timer_delete.c)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/timer_settime.c)
+endif(NOT HAVE_LIBRT)
+
+if(NOT HAVE_GETLINE)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/getline.c)
+endif(NOT HAVE_GETLINE)
+
+if(NOT HAVE_GETTIMEOFDAY)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/gettimeofday.c)
+endif(NOT HAVE_GETTIMEOFDAY)
+
+if(NOT HAVE_DECL_LOCALTIME_R)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/localtime_r.c)
+endif(NOT HAVE_DECL_LOCALTIME_R)
+
+if(NOT HAVE_MALLOC)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/malloc.c)
+endif(NOT HAVE_MALLOC)
+
+if(NOT HAVE_REALLOC)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/realloc.c)
+endif(NOT HAVE_REALLOC)
+
+if(NOT HAVE_SNPRINTF)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/snprintf.c)
+endif(NOT HAVE_SNPRINTF)
+
+if(NOT HAVE_DECL_STRDUP AND NOT HAVE__STRDUP)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/strdup.c)
+endif(NOT HAVE_DECL_STRDUP AND NOT HAVE__STRDUP)
+
+if(NOT HAVE_DECL_STRSIGNAL)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/strsignal.c)
+endif(NOT HAVE_DECL_STRSIGNAL)
+
+if(NOT HAVE_DECL_ALARM)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/alarm.c)
+endif(NOT HAVE_DECL_ALARM)
+
+if(NOT HAVE_PTHREAD)
+  list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../lib/pthread_mutex.c)
+endif()
+
 set(HEADERS
   ${CONFIG_HEADER}
   ${CMAKE_CURRENT_BINARY_DIR}/check.h
@@ -54,93 +104,32 @@ configure_file(check.h.in check.h @ONLY)
 add_library(check STATIC ${SOURCES} ${HEADERS})
 add_library(Check::check ALIAS check)
 
-
 # We would like to create an OBJECT library but currently they are
 # too unreliable and cumbersome,
 # especially with target_link_libraries and install(EXPORT...
 # https://stackoverflow.com/questions/38832528/transitive-target-include-directories-on-object-libraries
 # So we instead do the work twice.
-add_library(checkShared SHARED ${SOURCES} ${HEADERS})
-add_library(Check::checkShared ALIAS checkShared)
-
-# Add parts of libcompat as required
-target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/fpclassify.c)
-target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/fpclassify.c)
-
-if (NOT HAVE_LIBRT)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/clock_gettime.c)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/timer_create.c)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/timer_delete.c)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/timer_settime.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/clock_gettime.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/timer_create.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/timer_delete.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/timer_settime.c)
-endif(NOT HAVE_LIBRT)
-
-if(NOT HAVE_GETLINE)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/getline.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/getline.c)
-endif(NOT HAVE_GETLINE)
-
-if(NOT HAVE_GETTIMEOFDAY)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/gettimeofday.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/gettimeofday.c)
-endif(NOT HAVE_GETTIMEOFDAY)
-
-if(NOT HAVE_DECL_LOCALTIME_R)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/localtime_r.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/localtime_r.c)
-endif(NOT HAVE_DECL_LOCALTIME_R)
-
-if(NOT HAVE_MALLOC)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/malloc.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/malloc.c)
-endif(NOT HAVE_MALLOC)
-
-if(NOT HAVE_REALLOC)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/realloc.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/realloc.c)
-endif(NOT HAVE_REALLOC)
-
-if(NOT HAVE_SNPRINTF)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/snprintf.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/snprintf.c)
-endif(NOT HAVE_SNPRINTF)
-
-if(NOT HAVE_DECL_STRDUP AND NOT HAVE__STRDUP)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/strdup.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/strdup.c)
-endif(NOT HAVE_DECL_STRDUP AND NOT HAVE__STRDUP)
-
-if(NOT HAVE_DECL_STRSIGNAL)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/strsignal.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/strsignal.c)
-endif(NOT HAVE_DECL_STRSIGNAL)
-
-if(NOT HAVE_DECL_ALARM)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/alarm.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/alarm.c)
-endif(NOT HAVE_DECL_ALARM)
-
-if(NOT HAVE_PTHREAD)
-  target_sources(check PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/pthread_mutex.c)
-  target_sources(checkShared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/pthread_mutex.c)
-endif()
+if (BUILD_SHARED_LIBS)
+  add_library(checkShared SHARED ${SOURCES} ${HEADERS})
+  add_library(Check::checkShared ALIAS checkShared)
+endif (BUILD_SHARED_LIBS)
 
 # Include libraries if available
 if (HAVE_LIBM)
-  target_link_libraries(check PUBLIC m)
-  target_link_libraries(checkShared PUBLIC m)
+  list(APPEND ADDITIONAL_LIBS m)
 endif (HAVE_LIBM)
 if (HAVE_LIBRT)
-  target_link_libraries(check PUBLIC rt)
-  target_link_libraries(checkShared PUBLIC rt)
+  list(APPEND ADDITIONAL_LIBS rt)
 endif (HAVE_LIBRT)
 if (HAVE_SUBUNIT)
-  target_link_libraries(check PUBLIC subunit)
-  target_link_libraries(checkShared PUBLIC subunit)
+  list(APPEND ADDITIONAL_LIBS subunit)
 endif (HAVE_SUBUNIT)
+
+target_link_libraries(check PUBLIC ${ADDITIONAL_LIBS})
+if (BUILD_SHARED_LIBS)
+  target_link_libraries(checkShared PUBLIC m)
+endif (BUILD_SHARED_LIBS)
+
 
 if(MSVC)
   target_compile_definitions(checkShared
@@ -168,27 +157,35 @@ if (MSVC)
   # So we call it this:
   set(LIBRARY_OUTPUT_NAME "checkDynamic")
 endif (MSVC)
+if (BUILD_SHARED_LIBS)
 set_target_properties(checkShared PROPERTIES
   OUTPUT_NAME ${LIBRARY_OUTPUT_NAME}
   VERSION ${PROJECT_VERSION}
   SOVERSION ${PROJECT_VERSION_MAJOR}
   PUBLIC_HEADER "${public_headers}"
 )
+endif (BUILD_SHARED_LIBS)
 target_include_directories(check
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>
     $<INSTALL_INTERFACE:include>
 )
+if (BUILD_SHARED_LIBS)
 target_include_directories(checkShared
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>
     $<INSTALL_INTERFACE:include>
-)
+ )
+endif (BUILD_SHARED_LIBS)
 
 if(NOT THIS_IS_SUBPROJECT)
-  install(TARGETS check checkShared
+  if (BUILD_SHARED_LIBS)
+    set(SHARED_LIBNAME checkShared)
+  endif ()
+
+  install(TARGETS check ${SHARED_LIBNAME}
     EXPORT check-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
BUILD_SHARED_LIBS is a standard CMake option [1] that specifies whether shared libraries should be built or not. This commit adjusts src/CMakeLists.txt to observe this variable to decide whether the shared library variant should be built or not. This allows check to only build a static library in environments where only a static library can be compiled.

This needs a bit of refactoring to avoid duplication:

- Additional source files from libcompat are directly added to the ${SOURCES} variable as needed

- Additional libraries are collected into ${ADDITIONAL_LIBS} before being associated to the static library and shared library (if enabled)

[1] https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html

Fixes:

__uClibc_main.c:(.text+0x12c): undefined reference to `__fini_array_end'
/home/autobuild/autobuild/instance-20/output-1/host/lib/gcc/sparc-buildroot-linux-uclibc/13.3.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: __uClibc_main.c:(.text+0x130): undefined reference to `__fini_array_start'
/home/autobuild/autobuild/instance-20/output-1/host/lib/gcc/sparc-buildroot-linux-uclibc/13.3.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: __uClibc_main.c:(.text+0x134): undefined reference to `__fini_array_end'