### PR TITLE
Fix Memory Sanitation Incompatibility

### DIFF
--- a/src/check_error.c
+++ b/src/check_error.c
@@ -62,15 +62,18 @@ void *emalloc(size_t n)
     p = malloc(n);
     if(p == NULL)
         eprintf("malloc of " CK_FMT_ZU " bytes failed:", __FILE__, __LINE__ - 2, n);
+    memset(p, 0xAA, n);
     return p;
 }
 
-void *erealloc(void *ptr, size_t n)
+void *erealloc(void *ptr, size_t old_n, size_t n)
 {
     void *p;
 
     p = realloc(ptr, n);
     if(p == NULL)
         eprintf("realloc of " CK_FMT_ZU " bytes failed:", __FILE__, __LINE__ - 2, n);
+    if(n > old_n)
+      memset(p+old_n, 0xAA, n-old_n);
     return p;
 }

--- a/src/check_error.h
+++ b/src/check_error.h
@@ -34,6 +34,6 @@ void eprintf(const char *fmt, const char *file, int line,
              ...) CK_ATTRIBUTE_NORETURN CK_ATTRIBUTE_FORMAT(printf, 1, 4);
 /* malloc or die */
 void *emalloc(size_t n);
-void *erealloc(void *, size_t n);
+void *erealloc(void *, size_t old_n, size_t n);
 
 #endif /*ERROR_H */

--- a/src/check_list.c
+++ b/src/check_list.c
@@ -46,8 +46,8 @@ static void maybe_grow(List * lp)
 {
     if(lp->n_elts >= lp->max_elts)
     {
+        lp->data = (void **)erealloc(lp->data, lp->max_elts * sizeof(lp->data[0]), lp->max_elts * LGROW * sizeof(lp->data[0]));
         lp->max_elts *= LGROW;
-        lp->data = (void **)erealloc(lp->data, lp->max_elts * sizeof(lp->data[0]));
     }
 }
 

--- a/src/check_str.c
+++ b/src/check_str.c
@@ -78,6 +78,7 @@ char *ck_strdup_printf(const char *fmt, ...)
 {
     /* Guess we need no more than 100 bytes. */
     size_t size = 100;
+    size_t new_size;
     char *p;
     va_list ap;
 
@@ -96,11 +97,12 @@ char *ck_strdup_printf(const char *fmt, ...)
 
         /* Else try again with more space. */
         if(n > -1)              /* C99 conform vsnprintf() */
-            size = (size_t) n + 1;      /* precisely what is needed */
+            new_size = (size_t) n + 1;      /* precisely what is needed */
         else                    /* glibc 2.0 */
-            size *= 2;          /* twice the old size */
+            new_size *= 2;          /* twice the old size */
 
-        p = (char *)erealloc(p, size);
+        p = (char *)erealloc(p, size, new_size);
+        size = new_size;
     }
 }
 


### PR DESCRIPTION
When running the tutorial project while compiling with clang v18.1.8's memory sanitizer, the result is a panic in the ppack() function for writing unitialized memory with fwrite(). Manual inspection tells me that the memory in question is in fact initialized, and valgrind confirms that there is no use of unitialized memory, so this is ultimately an issue with clang's memory sanitizer, but is nonetheless annoying. I have confirmed that setting all the memory allocated in emalloc() to 0xAA (or any other value) fixes this issue, however if memory is allocated in erealloc(), I was able to confirm that the same issue would occur, and making erealloc() capable of initializing all the excess memory required me to change the signature of the function, which might be a breaking change.