### PR TITLE
doc/check.texi: Fix do_install error with automake 1.18

### DIFF
--- a/doc/check.texi
+++ b/doc/check.texi
@@ -2258,7 +2258,6 @@ cmake -Dcheck_ROOT=${INSTALL_PREFIX}
 
 Then use Check in your @file{CMakeLists.txt} like this:
 
-@verbatim
 find_package(check <check_version if wanted> REQUIRED CONFIG)
 
 add_executable(myproj.test myproj.test.c)


### PR DESCRIPTION
Fixed do_install error with automake 1.18
$ makeinfo -I ../../check-0.15.2/doc -o ../../check-0.15.2/doc/check.info \
    ../../check-0.15.2/doc/check.texi
[snip]
check.texi:2329: no matching `@end verbatim'
[snip]

The automake before 1.17's mdate-sh couldn't update libcheck's doc/version.texi, so the doc/check.info wasn't re-generated, then we couldn't see the build error.