### PR TITLE
Fix compilation using MinGW-W64 13 and later

### DIFF
--- a/lib/libcompat.h
+++ b/lib/libcompat.h
@@ -143,6 +143,7 @@ extern int fpclassify(double d);
 
 /* provides localtime and struct tm */
 #ifdef HAVE_SYS_TIME_H
+#define WIN_PTHREADS_TIME_H 1
 #include <sys/time.h>
 #endif /* !HAVE_SYS_TIME_H */
 #include <time.h>

--- a/lib/libcompat.h
+++ b/lib/libcompat.h
@@ -143,9 +143,18 @@ extern int fpclassify(double d);
 
 /* provides localtime and struct tm */
 #ifdef HAVE_SYS_TIME_H
+#ifdef __MINGW64__
+#include <_mingw.h>
+/* Version 13 and later of mingw-w64 provides an inline definition of
+   clock_gettime() in pthread_time.h, which conflicts with our version
+   from clock_gettime.c.  By defining WIN_PTHREADS_TIME_H here we prevent
+   the pthread_time.h header from being included. */
+#if __MINGW64_VERSION_MAJOR > 12
 #define WIN_PTHREADS_TIME_H 1
+#endif
+#endif /* __MINGW64__ */
 #include <sys/time.h>
-#endif /* !HAVE_SYS_TIME_H */
+#endif /* HAVE_SYS_TIME_H */
 #include <time.h>
 
 /* declares fork(), _POSIX_VERSION.  according to Autoconf.info,


### PR DESCRIPTION
Version 13 of MinGW-W64 changed the declaration of `clock_gettime()` in `pthread_time.h` to a function definition which calls either `clock_gettime32()` or `clock_gettime64()`, see https://github.com/mingw-w64/mingw-w64/blob/v13.x/mingw-w64-libraries/winpthreads/include/pthread_time.h. This conflicts with check's definition of `clock_gettime()` in `clock_gettime.c`.  In order to prevent this, we can define `WIN_PTHREADS_TIME_H` in `libcompat.h` to prevent the contents of `pthread_time.h` from being included.