### PR TITLE
Fix tr_rtype return type

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -559,7 +559,7 @@ const char *tr_lfile(TestResult * tr)
     return tr->file;
 }
 
-int tr_rtype(TestResult * tr)
+enum test_result tr_rtype(TestResult * tr)
 {
     return tr->rtype;
 }

--- a/src/check.h.in
+++ b/src/check.h.in
@@ -1886,7 +1886,7 @@ enum ck_result_ctx
  *
  * @since 0.6.0
  */
-CK_DLL_EXP int CK_EXPORT tr_rtype(TestResult * tr);
+CK_DLL_EXP enum test_result CK_EXPORT tr_rtype(TestResult * tr);
 
 /**
  * Retrieve context in which the result occurred for the given test result.


### PR DESCRIPTION
Right now the return type of the `tr_rtype()` API is `int`. Since there's an `enum test_result` that `rtype` is defined in terms of elsewhere, the API should also use that.