### PR TITLE
Add tr_tname API

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -574,6 +574,11 @@ const char *tr_tcname(TestResult * tr)
     return tr->tcname;
 }
 
+const char *tr_tname(TestResult * tr)
+{
+    return tr->tname;
+}
+
 static enum fork_status _fstat = CK_FORK;
 
 void set_fork_status(enum fork_status fstat)

--- a/src/check.h.in
+++ b/src/check.h.in
@@ -1944,6 +1944,17 @@ CK_DLL_EXP const char *CK_EXPORT tr_lfile(TestResult * tr);
 CK_DLL_EXP const char *CK_EXPORT tr_tcname(TestResult * tr);
 
 /**
+ * Retrieve test name in which a failure occurred, if applicable.
+ *
+ * @return If the test resulted in a failure, returns a string
+ *          containing the name of the test where the failure
+ *          occurred; otherwise returns NULL.
+ *
+ * @since 0.15.3
+ */
+CK_DLL_EXP const char *CK_EXPORT tr_tname(TestResult * tr);
+
+/**
  * Creates a suite runner for the given suite.
  *
  * Once created, additional suites can be added to the
@@ -2127,7 +2138,8 @@ CK_DLL_EXP TestResult **CK_EXPORT srunner_failures(SRunner * sr);
  * failures due to setup function failure.
  *
  * Information about individual results can be queried using:
- * tr_rtype(), tr_ctx(), tr_msg(), tr_lno(), tr_lfile(), and tr_tcname().
+ * tr_rtype(), tr_ctx(), tr_msg(), tr_lno(), tr_lfile(), tr_name(),
+ * and tr_tcname().
  *
  * Memory is malloc'ed and must be freed; however free the entire structure
  * instead of individual test cases.

--- a/tests/check_check_master.c
+++ b/tests/check_check_master.c
@@ -605,6 +605,18 @@ START_TEST(test_check_tcnames)
 }
 END_TEST
 
+START_TEST(test_check_tnames)
+{
+  const char *tname;
+  tname = tr_tname(tr_all_array[_i]);
+  if (strcmp(tname, master_tests[_i].test_name) != 0) {
+    ck_abort_msg("Expected '%s', got '%s' for test %d:%s",
+         master_tests[_i].test_name, tname,
+         _i, master_tests[_i].test_name);
+  }
+}
+END_TEST
+
 START_TEST(test_check_test_names)
 {
   int i;
@@ -742,6 +754,7 @@ Suite *make_master_suite (void)
   tcase_add_test (tc_core, test_check_failure_lfiles);
   tcase_add_test (tc_core, test_check_test_names);
   tcase_add_loop_test (tc_core, test_check_tcnames, 0, sub_ntests);
+  tcase_add_loop_test (tc_core, test_check_tnames, 0, sub_ntests);
   tcase_add_loop_test (tc_core, test_check_all_msgs, 0, sub_ntests);
   tcase_add_loop_test (tc_core, test_check_all_ftypes, 0, nr_of_master_tests);
   tcase_add_unchecked_fixture(tc_fixture, test_fixture_setup,


### PR DESCRIPTION
Right now you can only get the test case name from a `TestResult`, using the `tr_tcname()` API. This means if you're trying to hook Check's result reporting into some other system, you can only get half the information you need to describe a test's success or failure. Since `TestResult` tracks the test name too, this can be easily remedied by also exposing a `tr_tname()` API.